### PR TITLE
Added command to install ddgs module to remediate module import error…

### DIFF
--- a/workshops/diy-agents-with-sagemaker-and-bedrock/4-frameworks/smolagents/smolagents-example.ipynb
+++ b/workshops/diy-agents-with-sagemaker-and-bedrock/4-frameworks/smolagents/smolagents-example.ipynb
@@ -9,7 +9,8 @@
    },
    "outputs": [],
    "source": [
-    "%pip install smolagents \"smolagents[litellm]\" -qU"
+    "%pip install smolagents \"smolagents[litellm]\" -qU\n",
+    "%pip install ddgs"
    ]
   },
   {


### PR DESCRIPTION
… in following cells.

*Issue #, if available:*

`ImportError: You must install package `ddgs` to run this tool: for instance run `pip install ddgs`.`

*Description of changes:*

Added `%pip install ddgs` in the notebook to remediate the error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
