### PR TITLE
Fix f-string nested quote syntax

### DIFF
--- a/workshops/diy-agents-with-sagemaker-and-bedrock/99-use-cases/sagemaker-endpoint-as-tool/tampered_image_detection.py
+++ b/workshops/diy-agents-with-sagemaker-and-bedrock/99-use-cases/sagemaker-endpoint-as-tool/tampered_image_detection.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageChops, ImageEnhance
 
 def convert_to_ela_image(path, quality):
     filename = path
-    resaved_filename = f'/tmp/{path.split('/')[-1]}.jpg'
+    resaved_filename = f'/tmp/{path.split("/")[-1]}.jpg'
     im = Image.open(filename)
     bm = im.convert('RGB')
     im.close()


### PR DESCRIPTION
## Summary
- Fix f-string nested quote syntax in `tampered_image_detection.py` for Python <3.12 compatibility

## Change
```python
# Before
resaved_filename = f'/tmp/{path.split('/')[-1]}.jpg'

# After  
resaved_filename = f'/tmp/{path.split("/")[-1]}.jpg'
```

Fixes #97

🤖 Generated with [Claude Code](https://claude.ai/claude-code)