### PR TITLE
Lab 4 improvements for workshop setting

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "### Split and transform the dataset\n",
     "\n",
-    "For this workshop, we only require a subset of the dataset. For the evaluation dataset we limit the number of samples to 100 to make sure the lab completes in a reasonable time. The maximum supported number of samples by LLM as a Judge (LLMaaJ) is 1000."
+    "For this workshop, we only require a subset of the dataset. For the evaluation dataset we limit the number of samples to 50 to make sure the lab completes in a reasonable time. The maximum supported number of samples by LLM as a Judge (LLMaaJ) is 1000."
    ]
   },
   {

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "train, val = train_test_split(df, train_size=8000, test_size=100, random_state=42)\n",
+    "train, val = train_test_split(df, train_size=4000, test_size=50, random_state=42)\n",
     "\n",
     "print(\"Number of train elements: \", len(train))\n",
     "print(\"Number of test elements: \", len(val))"

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "##  Prepare the dataset\n",
     "\n",
-    "We are going to use the [Human-Like-DPO-Dataset](https://huggingface.co/datasets/HumanLLMs/Human-Like-DPO-Dataset) that was created as part of research aimed at improving conversational fluency and engagement in large language models. It is suitable for formats like Direct Preference Optimization (DPO) to guide models toward generating more human-like responses, although in this example we'll use just the chosen response to implement RLAIF.\n",
+    "We are going to use the [Human-Like-DPO-Dataset](https://huggingface.co/datasets/HumanLLMs/Human-Like-DPO-Dataset) that was created as part of research aimed at improving conversational fluency and engagement in large language models. It is suitable for formats like Direct Preference Optimization (DPO) to guide models toward generating more human-like responses. In this lab, we use the `chosen` response as ground truth for evaluation only — during RLAIF training, the model generates its own responses which are scored by an AI judge.\n",
     "\n",
     "### Download and preview the dataset"
    ]

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/1-prepare-data.ipynb
@@ -102,7 +102,7 @@
     "dataset = load_dataset(\"HumanLLMs/Human-Like-DPO-Dataset\", split=\"train\")\n",
     "\n",
     "df = pd.DataFrame(dataset)\n",
-    "df.head()"
+    "df[[\"prompt\"]].head()"
    ]
   },
   {
@@ -157,7 +157,7 @@
     "            ],\n",
     "            \"ability\": \"human-like\",\n",
     "            \"reward_model\": {\n",
-    "                \"ground_truth\": sample.get(\"chosen\"),\n",
+    "                \"ground_truth\": \"\",\n",
     "                \"style\": \"llmj\",\n",
     "            }\n",
     "        }\n",
@@ -318,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
@@ -1,0 +1,271 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Reinforcement Learning From AI Feedback (RLAIF) with Serverless customization on SageMaker AI\n",
+    "\n",
+    "## Lab 4.3b - Import Pre-trained Model from S3\n",
+    "\n",
+    "This notebook is an **alternative to notebook 3 (fine-tuning)**. Instead of running a full RLAIF training job (which can take a long time), you can use a pre-trained model that is already available on S3.\n",
+    "\n",
+    "This notebook will:\n",
+    "1. Import the model artifacts from S3\n",
+    "2. Create a Model Package Group (if it doesn't exist)\n",
+    "3. Register the model as a Model Package in the SageMaker Model Registry\n",
+    "\n",
+    "After running this notebook, you can proceed directly to **notebook 4 (evaluation)** and **notebook 5 (deployment)**.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "### AWS Access Setup and dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = Session()\n",
+    "sagemaker_session_bucket = None\n",
+    "\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "try:\n",
+    "    role = get_execution_role()\n",
+    "except ValueError:\n",
+    "    iam = boto3.client(\"iam\")\n",
+    "    role = iam.get_role(RoleName=\"sagemaker_execution_role\")[\"Role\"][\"Arn\"]\n",
+    "\n",
+    "sess = Session(default_bucket=sagemaker_session_bucket)\n",
+    "bucket_name = sess.default_bucket()\n",
+    "region = sess.boto_region_name\n",
+    "\n",
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {bucket_name}\")\n",
+    "print(f\"sagemaker session region: {region}\")\n",
+    "\n",
+    "project_prefix = \"humanlike-rlaif\"\n",
+    "base_model_jumpstart_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
+    "base_model_shortname = \"qwen25-7b\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e2f3a4",
+   "metadata": {},
+   "source": [
+    "## Download pre-trained model and upload to your S3 bucket\n",
+    "\n",
+    "Download the model artifacts from the workshop asset URL and upload them to your own S3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pretrained_model_s3_uri = f\"s3://{bucket_name}/{project_prefix}-{base_model_shortname}/checkpoints/hf_merged/\"\n",
+    "\n",
+    "# Download from Hugging Face and upload to S3 using CRT\n",
+    "!pip install -qU huggingface_hub[hf_transfer]\n",
+    "import os\n",
+    "os.environ[\"HF_HUB_ENABLE_HF_TRANSFER\"] = \"1\"\n",
+    "\n",
+    "from huggingface_hub import snapshot_download\n",
+    "local_dir = \"/tmp/qwen25-7b-hla\"\n",
+    "snapshot_download(repo_id=\"esterk/qwen2.5-7b-hla\", local_dir=local_dir)\n",
+    "\n",
+    "!aws s3 sync {local_dir} {pretrained_model_s3_uri}\n",
+    "\n",
+    "print(f\"\\nPre-trained model S3 URI: {pretrained_model_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1a2b3c4",
+   "metadata": {},
+   "source": [
+    "### Verify the model artifacts exist on S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2b3c4d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_client = boto3.client(\"s3\")\n",
+    "\n",
+    "# Parse bucket and prefix from the S3 URI\n",
+    "s3_parts = pretrained_model_s3_uri.replace(\"s3://\", \"\").split(\"/\", 1)\n",
+    "s3_bucket = s3_parts[0]\n",
+    "s3_prefix = s3_parts[1] if len(s3_parts) > 1 else \"\"\n",
+    "\n",
+    "response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=10)\n",
+    "\n",
+    "if \"Contents\" in response:\n",
+    "    print(f\"\u2705 Found {response['KeyCount']} objects (showing up to 10):\")\n",
+    "    for obj in response[\"Contents\"]:\n",
+    "        print(f\"  - {obj['Key']} ({obj['Size']:,} bytes)\")\n",
+    "else:\n",
+    "    print(\"\u274c No objects found at the specified S3 path. Please verify the URI.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Create Model Package Group\n",
+    "\n",
+    "Create or retrieve the Model Package Group in the SageMaker Model Registry. This is the same group used by the fine-tuning notebook, so the evaluation and deployment notebooks will work seamlessly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2d3e4f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botocore.exceptions import ClientError\n",
+    "from sagemaker.core.resources import ModelPackageGroup\n",
+    "\n",
+    "model_package_group_name = f\"{project_prefix}-{base_model_shortname}\"\n",
+    "\n",
+    "try:\n",
+    "    model_package_group = ModelPackageGroup.get(\n",
+    "        model_package_group_name=model_package_group_name\n",
+    "    )\n",
+    "    print(f\"Model Package Group already exists: {model_package_group_name}\")\n",
+    "except ClientError:\n",
+    "    model_package_group = ModelPackageGroup.create(\n",
+    "        model_package_group_name=model_package_group_name,\n",
+    "        model_package_group_description=\"Store models from SageMaker serverless RLAIF customization\",\n",
+    "    )\n",
+    "    print(f\"Created Model Package Group: {model_package_group_name}\")\n",
+    "\n",
+    "print(f\"Model Package Group ARN: {model_package_group.model_package_group_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Register the Model Package\n",
+    "\n",
+    "Register the pre-trained model from S3 as a versioned Model Package. This makes it available for the evaluation and deployment notebooks, just as if it had been produced by a training job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2f3a4b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm_client = boto3.client(\"sagemaker\", region_name=region)\n",
+    "\n",
+    "response = sm_client.create_model_package(\n",
+    "    ModelPackageGroupName=model_package_group_name,\n",
+    "    ModelPackageDescription=\"Pre-trained RLAIF model imported from S3\",\n",
+    "    InferenceSpecification={\n",
+    "        \"Containers\": [\n",
+    "            {\n",
+    "                \"ModelDataSource\": {\n",
+    "                    \"S3DataSource\": {\n",
+    "                        \"S3Uri\": pretrained_model_s3_uri,\n",
+    "                        \"S3DataType\": \"S3Prefix\",\n",
+    "                        \"CompressionType\": \"None\",\n",
+    "                    }\n",
+    "                },\n",
+    "                \"BaseModel\": {\n",
+    "                    \"HubContentName\": base_model_jumpstart_id,\n",
+    "                    \"HubContentVersion\": \"1.26.0\",\n",
+    "                    \"RecipeName\": \"verl-grpo-rlaif-qwen-2-dot-5-7b-instruct-lora\",\n",
+    "                },\n",
+    "            }\n",
+    "        ],\n",
+    "    },\n",
+    "    ModelApprovalStatus=\"Approved\",\n",
+    ")\n",
+    "\n",
+    "model_package_arn = response[\"ModelPackageArn\"]\n",
+    "print(f\"\u2705 Created Model Package: {model_package_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "### Verify the registered Model Package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import ModelPackage\n",
+    "\n",
+    "model_package = ModelPackage.get(model_package_arn)\n",
+    "\n",
+    "print(f\"Model Package ARN: {model_package_arn}\")\n",
+    "print(f\"Model Package Group: {model_package_group_name}\")\n",
+    "print(f\"Status: {model_package.model_approval_status}\")\n",
+    "print(f\"S3 URI: {model_package.inference_specification.containers[0].model_data_source.s3_data_source.s3_uri}\")\n",
+    "print(f\"\\n\u2705 Model is registered and ready. You can now proceed to:\")\n",
+    "print(f\"   - Notebook 4 (evaluation): 4-evaluation.ipynb\")\n",
+    "print(f\"   - Notebook 5 (deployment): 5-deployment.ipynb\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 5,
+   "nbformat": 4,
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
@@ -84,16 +84,28 @@
    "source": [
     "pretrained_model_s3_uri = f\"s3://{bucket_name}/{project_prefix}-{base_model_shortname}/checkpoints/hf_merged/\"\n",
     "\n",
-    "# Download from Hugging Face and upload to S3 using CRT\n",
-    "!pip install -qU huggingface_hub[hf_transfer]\n",
-    "import os\n",
-    "os.environ[\"HF_HUB_ENABLE_HF_TRANSFER\"] = \"1\"\n",
+    "!pip install -qU huggingface_hub 2>/dev/null\n",
+    "\n",
+    "import os, gc\n",
+    "os.environ[\"HF_HUB_ENABLE_HF_TRANSFER\"] = \"0\"\n",
+    "os.environ[\"HF_HUB_DOWNLOAD_WORKERS\"] = \"1\"\n",
+    "os.environ[\"HF_HUB_DISABLE_IMPLICIT_TOKEN\"] = \"1\"\n",
+    "\n",
+    "# Free up memory before starting\n",
+    "gc.collect()\n",
     "\n",
     "from huggingface_hub import snapshot_download\n",
     "local_dir = \"/tmp/qwen25-7b-hla\"\n",
-    "snapshot_download(repo_id=\"esterk/qwen2.5-7b-hla\", local_dir=local_dir)\n",
+    "snapshot_download(\n",
+    "    repo_id=\"esterk/qwen2.5-7b-hla\",\n",
+    "    local_dir=local_dir,\n",
+    "    max_workers=1,\n",
+    "    resume_download=True,  # resume if interrupted\n",
+    "    etag_timeout=30,\n",
+    ")\n",
     "\n",
-    "!aws s3 sync {local_dir} {pretrained_model_s3_uri}\n",
+    "!aws s3 sync {local_dir} {pretrained_model_s3_uri} --quiet\n",
+    "!rm -rf {local_dir}\n",
     "\n",
     "print(f\"\\nPre-trained model S3 URI: {pretrained_model_s3_uri}\")"
    ]
@@ -123,11 +135,11 @@
     "response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=10)\n",
     "\n",
     "if \"Contents\" in response:\n",
-    "    print(f\"\u2705 Found {response['KeyCount']} objects (showing up to 10):\")\n",
+    "    print(f\"✅ Found {response['KeyCount']} objects (showing up to 10):\")\n",
     "    for obj in response[\"Contents\"]:\n",
     "        print(f\"  - {obj['Key']} ({obj['Size']:,} bytes)\")\n",
     "else:\n",
-    "    print(\"\u274c No objects found at the specified S3 path. Please verify the URI.\")"
+    "    print(\"❌ No objects found at the specified S3 path. Please verify the URI.\")"
    ]
   },
   {
@@ -215,7 +227,7 @@
     ")\n",
     "\n",
     "model_package_arn = response[\"ModelPackageArn\"]\n",
-    "print(f\"\u2705 Created Model Package: {model_package_arn}\")"
+    "print(f\"✅ Created Model Package: {model_package_arn}\")"
    ]
   },
   {
@@ -241,10 +253,26 @@
     "print(f\"Model Package Group: {model_package_group_name}\")\n",
     "print(f\"Status: {model_package.model_approval_status}\")\n",
     "print(f\"S3 URI: {model_package.inference_specification.containers[0].model_data_source.s3_data_source.s3_uri}\")\n",
-    "print(f\"\\n\u2705 Model is registered and ready. You can now proceed to:\")\n",
+    "print(f\"\\n✅ Model is registered and ready. You can now proceed to:\")\n",
     "print(f\"   - Notebook 4 (evaluation): 4-evaluation.ipynb\")\n",
     "print(f\"   - Notebook 5 (deployment): 5-deployment.ipynb\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "122f6c89",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2142006",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -261,9 +289,9 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat_minor": 5,
-   "nbformat": 4,
-   "version": "3.13.3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/3b-import-model-from-s3.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pretrained_model_s3_uri = f\"s3://{bucket_name}/{project_prefix}-{base_model_shortname}/checkpoints/hf_merged/\"\n",
+    "model_s3_upload_uri = f\"s3://{bucket_name}/{project_prefix}-{base_model_shortname}/checkpoints/hf_merged/\"\npretrained_model_s3_uri = f\"s3://{bucket_name}/{project_prefix}-{base_model_shortname}/\"\n",
     "\n",
     "!pip install -qU huggingface_hub 2>/dev/null\n",
     "\n",
@@ -104,7 +104,7 @@
     "    etag_timeout=30,\n",
     ")\n",
     "\n",
-    "!aws s3 sync {local_dir} {pretrained_model_s3_uri} --quiet\n",
+    "!aws s3 sync {local_dir} {model_s3_upload_uri} --quiet\n",
     "!rm -rf {local_dir}\n",
     "\n",
     "print(f\"\\nPre-trained model S3 URI: {pretrained_model_s3_uri}\")"
@@ -135,11 +135,11 @@
     "response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=10)\n",
     "\n",
     "if \"Contents\" in response:\n",
-    "    print(f\"✅ Found {response['KeyCount']} objects (showing up to 10):\")\n",
+    "    print(f\"\u2705 Found {response['KeyCount']} objects (showing up to 10):\")\n",
     "    for obj in response[\"Contents\"]:\n",
     "        print(f\"  - {obj['Key']} ({obj['Size']:,} bytes)\")\n",
     "else:\n",
-    "    print(\"❌ No objects found at the specified S3 path. Please verify the URI.\")"
+    "    print(\"\u274c No objects found at the specified S3 path. Please verify the URI.\")"
    ]
   },
   {
@@ -227,7 +227,7 @@
     ")\n",
     "\n",
     "model_package_arn = response[\"ModelPackageArn\"]\n",
-    "print(f\"✅ Created Model Package: {model_package_arn}\")"
+    "print(f\"\u2705 Created Model Package: {model_package_arn}\")"
    ]
   },
   {
@@ -253,7 +253,7 @@
     "print(f\"Model Package Group: {model_package_group_name}\")\n",
     "print(f\"Status: {model_package.model_approval_status}\")\n",
     "print(f\"S3 URI: {model_package.inference_specification.containers[0].model_data_source.s3_data_source.s3_uri}\")\n",
-    "print(f\"\\n✅ Model is registered and ready. You can now proceed to:\")\n",
+    "print(f\"\\n\u2705 Model is registered and ready. You can now proceed to:\")\n",
     "print(f\"   - Notebook 4 (evaluation): 4-evaluation.ipynb\")\n",
     "print(f\"   - Notebook 5 (deployment): 5-deployment.ipynb\")"
    ]

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/4-evaluation.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/4-evaluation.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "### Configure LLM-as-Judge Evaluation\n",
     "\n",
-    "We set up two parallel evaluation jobs using Amazon Nova Pro as the judge model — one for the base model and one for our RLAIF fine-tuned model. Both use a custom \"human-like alignment\" metric that scores responses on naturalness, tone, and conversational flow against ground truth references. Running identical evaluations on both models lets us quantify the impact of RLAIF fine-tuning."
+    "We set up two parallel evaluation jobs using Amazon Nova Pro as the judge model \u2014 one for the base model and one for our RLAIF fine-tuned model. Both use a custom \"human-like alignment\" metric that scores responses on naturalness, tone, and conversational flow against ground truth references. Running identical evaluations on both models lets us quantify the impact of RLAIF fine-tuning."
    ]
   },
   {
@@ -198,8 +198,50 @@
    "source": [
     "---\n",
     "\n",
-    "## Analyze Evaluation results\n",
-    "### Download the evaluation output from S3"
+    "## Analyze Evaluation results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ee4628",
+   "metadata": {},
+   "source": [
+    "### [OPTION 1] Download pre-computed evaluation results\n",
+    "\n",
+    "The evaluation job can take **~45 minutes** to complete. If you don't want to wait, run the cell below to download pre-computed evaluation results and skip the next cell.\n",
+    "\n",
+    "If you prefer to use your own evaluation results, **skip this cell** and run the next one instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec32bf7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [OPTIONAL] Download pre-computed evaluation results to skip the ~45 min wait\n",
+    "import os\n",
+    "import boto3\n",
+    "\n",
+    "os.makedirs(\"./eval_results\", exist_ok=True)\n",
+    "\n",
+    "PRECOMPUTED_BUCKET = \"ws-assets-prod-iad-r-iad-ed304a55c2ca1aee\"\n",
+    "PRECOMPUTED_PREFIX = \"548b5be9-2da8-4c93-82f7-b0b474108ab3/lab4/eval_results\"\n",
+    "\n",
+    "s3 = boto3.client(\"s3\", region_name=\"us-east-1\")\n",
+    "s3.download_file(PRECOMPUTED_BUCKET, f\"{PRECOMPUTED_PREFIX}/base_eval.jsonl\", \"./eval_results/base_eval.jsonl\")\n",
+    "s3.download_file(PRECOMPUTED_BUCKET, f\"{PRECOMPUTED_PREFIX}/custom_eval.jsonl\", \"./eval_results/custom_eval.jsonl\")\n",
+    "\n",
+    "print(\"Downloaded pre-computed results to ./eval_results/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db964d03",
+   "metadata": {},
+   "source": [
+    "### [Option 2] Download the evaluation job output"
    ]
   },
   {
@@ -209,6 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Skip this cell if you already downloaded pre-computed results from the [OPTIONAL] cell above\n",
     "import os\n",
     "\n",
     "execution_id = execution.arn.split(\"/\")[-1]\n",
@@ -367,6 +410,14 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba83af7a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -385,7 +436,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
New notebook: 3b-import-model-from-s3.ipynb
- Alternative path for importing a pre-trained model directly from S3, skipping the fine-tuning step

1-prepare-data.ipynb
- Dataset preview now only shows the prompt column (hides chosen/rejected)
- Training dataset uses empty ground_truth instead of the chosen response
- Reduced sample sizes: 4,000 train / 50 eval
- Fixed misleading dataset description in markdown

4-evaluation.ipynb
- Added optional cell to download pre-computed evaluation results from the workshop assets S3 bucket, so participants don't have to wait ~45 min for the eval job to complete
- Added skip hints so participants know to run one download option or the other, not both
- Updated eval sample count in markdown to match code