### PR TITLE
lab1: update SFT workshop to Qwen3 8B with configurable base model

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/1-prepare-data.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/1-prepare-data.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "## Lab 1 - Data preparation\n",
     "\n",
-    "In this notebook, we are going to prepare the dataset for later on fine-tuning Qwen 2.5 - 7B Instruct"
+    "In this notebook, we are going to prepare the dataset for later on fine-tuning our base model Qwen 3 8B (configured in `config.py`)"
    ]
   },
   {

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
@@ -14,10 +14,64 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8jshrj1oci8",
+   "metadata": {},
+   "source": [
+    "### Choosing a base model\n",
+    "\n",
+    "The base model used across this lab is configured in [`config.py`](config.py). Want to try a different model? You can browse the available models on SageMaker JumpStart by running the cell below. To switch models, just update `BASE_MODEL_ID` in `config.py` — all notebooks in this lab will pick up the change automatically.\n",
+    "\n",
+    "> **Note:** Not every JumpStart model supports every customization technique (SFT, DPO, RLVR, etc.). If you hit a \"No recipes found\" error, that model may not support the technique used in this lab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a50bbb03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from config import BASE_MODEL_ID\n",
+    "\n",
+    "# Retrieve all JumpStart models that support customization (fine-tuning)\n",
+    "sm = boto3.client(\"sagemaker\")\n",
+    "models = []\n",
+    "kwargs = {\"HubName\": \"SageMakerPublicHub\", \"HubContentType\": \"Model\", \"MaxResults\": 100}\n",
+    "while True:\n",
+    "    response = sm.list_hub_contents(**kwargs)\n",
+    "    for item in response[\"HubContentSummaries\"]:\n",
+    "        keywords = item.get(\"HubContentSearchKeywords\", [])\n",
+    "        if \"@capability:customization\" in keywords:\n",
+    "            models.append(item[\"HubContentName\"])\n",
+    "    if \"NextToken\" in response:\n",
+    "        kwargs[\"NextToken\"] = response[\"NextToken\"]\n",
+    "    else:\n",
+    "        break\n",
+    "\n",
+    "models.sort()\n",
+    "print(f\"Current model: {BASE_MODEL_ID}\\n\")\n",
+    "print(f\"Available models ({len(models)}):\")\n",
+    "print(\"\\n\".join(models))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0c8e9836",
    "metadata": {},
    "source": [
     "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6o45bipecr4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
@@ -79,8 +133,9 @@
    "source": [
     "import os\n",
     "from sagemaker.ai_registry.dataset import DataSet\n",
+    "from config import BASE_MODEL_ID\n",
     "\n",
-    "base_model_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
+    "base_model_id = BASE_MODEL_ID\n",
     "\n",
     "training_dataset = DataSet.get(name=\"medical-o1-reasoning-sft-train\")\n",
     "val_dataset = DataSet.get(name=\"medical-o1-reasoning-sft-val\")\n",
@@ -121,7 +176,7 @@
     "from botocore.exceptions import ClientError\n",
     "from sagemaker.core.resources import ModelPackageGroup\n",
     "\n",
-    "model_package_group_name = f\"{base_model_id}-mpg\"\n",
+    "model_package_group_name = f\"{base_model_id}-sft-mpg\"\n",
     "\n",
     "try:\n",
     "    model_package_group = ModelPackageGroup.get(\n",
@@ -230,6 +285,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9v8acnopvmq",
+   "metadata": {},
+   "source": [
+    "### Kick off the training job\n",
+    "\n",
+    "The cell below submits the fine-tuning job asynchronously (`wait=False`), so it will return immediately without waiting for training to complete. Training typically takes **20 minutes** with the chosen dataset and hyperparameters, but will depend on the model and dataset size.\n",
+    "\n",
+    "Once the job is submitted, you can track its progress in two ways:\n",
+    "\n",
+    "1. **AWS Console** — Navigate to **SageMaker AI > Training > Training jobs** and search for the job name.\n",
+    "2. **SageMaker SDK** — Use the status-check cell further below to poll the job status programmatically."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "e215fec5",
@@ -245,6 +315,29 @@
     "\n",
     "pprint(training_job)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "xwxz0nes4mq",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the training job status\n",
+    "from sagemaker.core.resources import TrainingJob\n",
+    "\n",
+    "response = TrainingJob.get(training_job_name=TRAINING_JOB_NAME)\n",
+    "print(f\"Status: {response.training_job_status}\")\n",
+    "print(f\"Secondary: {response.secondary_status}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290547b2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-benchmark-evaluation.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-benchmark-evaluation.ipynb
@@ -34,6 +34,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "n69z85h9ut",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b1",
    "metadata": {},
    "outputs": [],
@@ -80,30 +91,15 @@
    "outputs": [],
    "source": [
     "from sagemaker.core.resources import ModelPackageGroup\n",
+    "from config import BASE_MODEL_ID\n",
     "\n",
-    "base_model_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
-    "base_model_version= \"*\"\n",
-    "model_package_group_name = f\"{base_model_id}-mpg\"\n",
+    "model_package_group_name = f\"{BASE_MODEL_ID}-sft-mpg\"\n",
     "model_package_version = \"1\"\n",
     "\n",
     "model_package_group = ModelPackageGroup.get(model_package_group_name)\n",
     "\n",
     "fine_tuned_model_package_arn = f\"{model_package_group.model_package_group_arn.replace('model-package-group', 'model-package', 1)}/{model_package_version}\"\n",
-    "print(f\"Fine-tuned Model Package ARN: {fine_tuned_model_package_arn}\")\n",
-    "\n",
-    "if default_prefix:\n",
-    "    output_path = f\"s3://{bucket_name}/{default_prefix}/{base_model_id}/benchmark-evaluation\"\n",
-    "else:\n",
-    "    output_path = f\"s3://{bucket_name}/{base_model_id}/benchmark-evaluation\"\n",
-    "\n",
-    "\n",
-    "if default_prefix:\n",
-    "    output_path_base = f\"s3://{bucket_name}/{default_prefix}/{base_model_id}/benchmark-evaluation-base\"\n",
-    "else:\n",
-    "    output_path_base = f\"s3://{bucket_name}/{base_model_id}/benchmark-evaluation-base\"\n",
-    "\n",
-    "print(f\"Evaluation base output path: {output_path_base}\")\n",
-    "print(f\"Evaluation output path: {output_path}\")"
+    "print(f\"Fine-tuned Model Package ARN: {fine_tuned_model_package_arn}\")"
    ]
   },
   {
@@ -118,9 +114,23 @@
     "    ModelPackageName=fine_tuned_model_package_arn\n",
     ")\n",
     "base_model_info = ft_response['InferenceSpecification']['Containers'][0]['BaseModel']\n",
+    "base_model_id = base_model_info['HubContentName']\n",
     "\n",
+    "print(f\"Base model ID: {base_model_id}\")\n",
     "print(base_model_info)\n",
-    "# {'HubContentName': 'huggingface-llm-qwen2-5-7b-instruct', 'HubContentVersion': '1.27.0', 'RecipeName': 'llmft_qwen2_5_7b_seq4k_gpu_sft_lora'}"
+    "\n",
+    "if default_prefix:\n",
+    "    output_path = f\"s3://{bucket_name}/{default_prefix}/{base_model_id}/benchmark-evaluation\"\n",
+    "else:\n",
+    "    output_path = f\"s3://{bucket_name}/{base_model_id}/benchmark-evaluation\"\n",
+    "\n",
+    "if default_prefix:\n",
+    "    output_path_base = f\"s3://{bucket_name}/{default_prefix}/{base_model_id}/benchmark-evaluation-base\"\n",
+    "else:\n",
+    "    output_path_base = f\"s3://{bucket_name}/{base_model_id}/benchmark-evaluation-base\"\n",
+    "\n",
+    "print(f\"Evaluation base output path: {output_path_base}\")\n",
+    "print(f\"Evaluation output path: {output_path}\")"
    ]
   },
   {
@@ -132,42 +142,37 @@
    },
    "outputs": [],
    "source": [
-    "import boto3\n",
+    "from sagemaker.serve.model_builder import ModelBuilder\n",
+    "from sagemaker.core.jumpstart.configs import JumpStartConfig\n",
+    "from sagemaker.train.configs import Compute\n",
     "\n",
-    "\n",
-    "base_model_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
     "base_mpg_name = f\"{base_model_id}-base-mpg\"\n",
     "\n",
     "# Step 1: Create model package group\n",
     "sm_client.create_model_package_group(\n",
     "    ModelPackageGroupName=base_mpg_name,\n",
-    "    ModelPackageGroupDescription=\"Base model package group for Qwen2.5-7B-Instruct\"\n",
+    "    ModelPackageGroupDescription=f\"Base model package group for {base_model_id}\"\n",
     ")\n",
     "print(f\"Created model package group: {base_mpg_name}\")\n",
     "\n",
-    "# Step 2: Register the base model as a model package\n",
-    "response = sm_client.create_model_package(\n",
-    "    ModelPackageGroupName=base_mpg_name,\n",
-    "    ModelPackageDescription=\"Qwen2.5-7B-Instruct base model\",\n",
-    "    InferenceSpecification={\n",
-    "        'Containers': [{\n",
-    "            'ModelDataSource': {\n",
-    "                'S3DataSource': {\n",
-    "                    'S3Uri': 's3://jumpstart-cache-prod-us-east-1/huggingface-llm/huggingface-llm-qwen2-5-7b-instruct/artifacts/inference/v1.0.0/',\n",
-    "                    'S3DataType': 'S3Prefix',\n",
-    "                    'CompressionType': 'None'\n",
-    "                }\n",
-    "            },\n",
-    "            'BaseModel': base_model_info\n",
-    "        }],\n",
-    "        'SupportedTransformInstanceTypes': ['ml.g5.12xlarge'],\n",
-    "        'SupportedRealtimeInferenceInstanceTypes': ['ml.g5.12xlarge'],\n",
-    "        'SupportedContentTypes': ['application/json'],\n",
-    "        'SupportedResponseMIMETypes': ['application/json'],\n",
-    "    },\n",
-    "    ModelApprovalStatus='Approved'\n",
+    "# Step 2: Use JumpStartConfig to resolve model artifacts automatically\n",
+    "jumpstart_config = JumpStartConfig(model_id=base_model_id)\n",
+    "model_builder = ModelBuilder.from_jumpstart_config(\n",
+    "    jumpstart_config=jumpstart_config,\n",
+    "    compute=Compute(instance_type=\"ml.g5.12xlarge\"),\n",
+    "    sagemaker_session=sess,\n",
+    "    role_arn=role,\n",
     ")\n",
-    "print(f\"Base Model Package ARN: {response['ModelPackageArn']}\")"
+    "\n",
+    "# Step 3: Register the base model as a model package\n",
+    "response = model_builder.register(\n",
+    "    model_package_group_name=base_mpg_name,\n",
+    "    content_types=[\"application/json\"],\n",
+    "    response_types=[\"application/json\"],\n",
+    "    inference_instances=[\"ml.g5.12xlarge\"],\n",
+    "    approval_status=\"Approved\",\n",
+    ")\n",
+    "print(f\"Base Model Package ARN: {response}\")"
    ]
   },
   {
@@ -265,13 +270,7 @@
    "cell_type": "markdown",
    "id": "a5",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 3. Run benchmark evaluation\n",
-    "\n",
-    "We set `evaluate_base_model=True` so SageMaker evaluates both the fine-tuned model and the original Qwen 2.5 7B Instruct base model side by side."
-   ]
+   "source": "---\n\n## 3. Run benchmark evaluation\n\nWe run two separate benchmark evaluations — one for the fine-tuned model and one for the base model — then compare the results."
   },
   {
    "cell_type": "code",
@@ -338,14 +337,6 @@
     "    pprint(execution)\n",
     "    pprint(execution.show_results())"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb6841cb-c5c4-4d9b-a9f0-80fab28a6144",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-evaluation.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-evaluation.ipynb
@@ -21,6 +21,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "id": "59k2cmvmc",
+   "source": "%load_ext autoreload\n%autoreload 2",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "markdown",
    "id": "6cc40c5a",
    "metadata": {},
@@ -84,15 +92,7 @@
    "id": "b03f3aa4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from sagemaker.ai_registry.dataset import DataSet\n",
-    "from sagemaker.core.resources import ModelPackageGroup\n",
-    "\n",
-    "base_model_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
-    "\n",
-    "model_package_group_name = f\"{base_model_id}-mpg\"\n",
-    "model_package_version = \"1\""
-   ]
+   "source": "from sagemaker.ai_registry.dataset import DataSet\nfrom sagemaker.core.resources import ModelPackageGroup\nfrom config import BASE_MODEL_ID\n\nbase_model_id = BASE_MODEL_ID\n\nmodel_package_group_name = f\"{base_model_id}-sft-mpg\"\nmodel_package_version = \"1\""
   },
   {
    "cell_type": "code",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4-deployment.ipynb
@@ -4,13 +4,7 @@
    "cell_type": "markdown",
    "id": "4e853a14",
    "metadata": {},
-   "source": [
-    "# Supervised Fine-Tuning (SFT) with Serverless customization on SageMaker AI\n",
-    "\n",
-    "## Lab 4 - LLM Deployment\n",
-    "\n",
-    "In this notebook, we are going to deploy the fine-tuned LLM using SageMaker Real-time endpoint"
-   ]
+   "source": "# Supervised Fine-Tuning (SFT) with Serverless customization on SageMaker AI\n\n## Lab 4 - Deploy to SageMaker Endpoint\n\nIn this notebook, we are going to deploy the fine-tuned LLM using SageMaker Real-time endpoint"
   },
   {
    "cell_type": "markdown",
@@ -18,6 +12,17 @@
    "metadata": {},
    "source": [
     "***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qd6htccls4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
@@ -88,10 +93,11 @@
    "outputs": [],
    "source": [
     "from sagemaker.core.resources import ModelPackage, ModelPackageGroup\n",
+    "from config import BASE_MODEL_ID\n",
     "\n",
-    "base_model_id = \"huggingface-llm-qwen2-5-7b-instruct\"\n",
+    "base_model_id = BASE_MODEL_ID\n",
     "\n",
-    "model_package_group_name = f\"{base_model_id}-mpg\"\n",
+    "model_package_group_name = f\"{base_model_id}-sft-mpg\"\n",
     "model_package_version = \"1\"\n",
     "\n",
     "model_name = f\"{base_model_id}-sft\"\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4a-deployment-bedrock.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4a-deployment-bedrock.ipynb
@@ -1,0 +1,384 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4e853a14",
+   "metadata": {},
+   "source": [
+    "# Supervised Fine-Tuning (SFT) with Serverless customization on SageMaker AI\n",
+    "\n",
+    "## Lab 4a - Deploy to Amazon Bedrock via Custom Model Import\n",
+    "\n",
+    "In this notebook, we deploy the fine-tuned LLM to Amazon Bedrock using [Custom Model Import](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html). This provides fully serverless inference — no endpoints or infrastructure to manage.\n",
+    "\n",
+    "**When to use this vs. Lab 4 (SageMaker Endpoint):**\n",
+    "- **Bedrock Custom Model Import (this notebook):** Fully serverless, no infrastructure to manage, billed per Custom Model Unit in 5-minute windows with scale-to-zero. Best when you want simplicity and don't need fine-grained control over the hosting environment.\n",
+    "- **SageMaker Endpoint (Lab 4):** Dedicated GPU instances, full control over instance type, scaling policies, and serving configuration. Best when you need predictable latency or cost optimization at high throughput."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2b6949b",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58a0a20b",
+   "metadata": {},
+   "source": [
+    "### Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f431a9f",
+   "metadata": {},
+   "source": [
+    "#### Setup and dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1dd0c02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import boto3\n",
+    "import os\n",
+    "from rich.pretty import pprint\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = Session()\n",
+    "sagemaker_session_bucket = None\n",
+    "\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    # set to default bucket if a bucket name is not given\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "try:\n",
+    "    role = get_execution_role()\n",
+    "except ValueError:\n",
+    "    iam = boto3.client(\"iam\")\n",
+    "    role = iam.get_role(RoleName=\"sagemaker_execution_role\")[\"Role\"][\"Arn\"]\n",
+    "\n",
+    "s3_client = boto3.client(\"s3\")\n",
+    "sess = Session(default_bucket=sagemaker_session_bucket)\n",
+    "sm_client = boto3.client(\"sagemaker\", region_name=sess.boto_region_name)\n",
+    "bucket_name = sess.default_bucket()\n",
+    "default_prefix = sess.default_bucket_prefix\n",
+    "\n",
+    "print(f\"sagemaker role arn: {role}\")\n",
+    "print(f\"sagemaker bucket: {sess.default_bucket()}\")\n",
+    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89088cc1",
+   "metadata": {},
+   "source": [
+    "#### Retrieve fine-tuned model artifacts\n",
+    "\n",
+    "This retrieves the merged fine-tuned model artifacts registered in the Model Package Group from Lab 2. The merged model (in Hugging Face format) is what we'll import into Bedrock.\n",
+    "\n",
+    "> **Note:** Edit `model_package_group_name` and `model_package_version` below if you used different values during fine-tuning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4206486",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import ModelPackage, ModelPackageGroup\n",
+    "from config import BASE_MODEL_ID\n",
+    "\n",
+    "base_model_id = BASE_MODEL_ID\n",
+    "\n",
+    "model_package_group_name = f\"{base_model_id}-sft-mpg\"\n",
+    "model_package_version = \"1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e911f4ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core import s3\n",
+    "\n",
+    "model_package_group = ModelPackageGroup.get(model_package_group_name)\n",
+    "\n",
+    "fine_tuned_model_package_group_arn = model_package_group.model_package_group_arn\n",
+    "print(f\"Fine-tuned Model Package Group ARN: {fine_tuned_model_package_group_arn}\")\n",
+    "\n",
+    "fine_tuned_model_package_arn = f\"{model_package_group.model_package_group_arn.replace('model-package-group', 'model-package', 1)}/{model_package_version}\"\n",
+    "print(f\"Fine-tuned Model Package ARN: {fine_tuned_model_package_arn}\")\n",
+    "\n",
+    "model_package = ModelPackage.get(fine_tuned_model_package_arn)\n",
+    "\n",
+    "# get the merged model artifact and deploy it\n",
+    "merged_model_s3_uri = (\n",
+    "    s3.s3_path_join(\n",
+    "        model_package.inference_specification.containers[\n",
+    "            0\n",
+    "        ].model_data_source.s3_data_source.s3_uri,\n",
+    "        \"checkpoints\",\n",
+    "        \"hf_merged\",\n",
+    "    )\n",
+    "    + \"/\"\n",
+    ")\n",
+    "print(merged_model_s3_uri)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bclqg62egoo",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gunf3hq04sg",
+   "metadata": {},
+   "source": [
+    "### Deploy as Custom Model Import on Amazon Bedrock\n",
+    "\n",
+    "[Amazon Bedrock Custom Model Import](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html) allows you to import fine-tuned models with custom weights into Bedrock for serverless inference. This eliminates the need to manage endpoints or infrastructure — Bedrock handles scaling automatically.\n",
+    "\n",
+    "**Supported architectures include:** Llama, Mistral, Mixtral, Qwen (Qwen2, Qwen2.5, Qwen3), and others.\n",
+    "\n",
+    "**Requirements:**\n",
+    "- Model files in Hugging Face format (`.safetensors`, `config.json`, `tokenizer.json`, etc.)\n",
+    "- Model stored in Amazon S3\n",
+    "- IAM role with Bedrock trust relationship and S3 read access"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ujlmu5qhyc",
+   "metadata": {},
+   "source": [
+    "#### IAM role for Bedrock Custom Model Import\n",
+    "\n",
+    "Bedrock requires an IAM role with a trust policy for `bedrock.amazonaws.com` and read access to the S3 bucket containing the model artifacts.\n",
+    "\n",
+    "**Follow [Create a service role for model import](https://docs.aws.amazon.com/bedrock/latest/userguide/model-import-iam-role.html) to create this role**, then paste the role ARN below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ezr1xtglb39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "from datetime import datetime\n",
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "bedrock_client = boto3.client(\"bedrock\", region_name=sess.boto_region_name)\n",
+    "bedrock_runtime = boto3.client(\"bedrock-runtime\", region_name=sess.boto_region_name)\n",
+    "\n",
+    "timestamp = datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "imported_model_name = f\"{base_model_id}-sft-imported\"\n",
+    "import_job_name = f\"{base_model_id}-sft-import-job-{timestamp}\"\n",
+    "\n",
+    "# REQUIRED: Paste the ARN of the IAM role you created for Bedrock Custom Model Import\n",
+    "bedrock_import_role_arn = \"<YOUR_BEDROCK_IMPORT_ROLE_ARN>\"\n",
+    "\n",
+    "assert bedrock_import_role_arn != \"<YOUR_BEDROCK_IMPORT_ROLE_ARN>\" and bedrock_import_role_arn.startswith(\"arn:aws:iam::\"), (\n",
+    "    \"You must provide a valid IAM role ARN for Bedrock Custom Model Import. \"\n",
+    "    \"Follow the instructions in the cell above to create one.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2q3h82nnfw4",
+   "metadata": {},
+   "source": [
+    "#### Submit Custom Model Import Job\n",
+    "\n",
+    "This creates an import job that loads the fine-tuned model from S3 into Bedrock. The `merged_model_s3_uri` from earlier points to the merged Hugging Face model artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3r141x6kdkg",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Model S3 URI: {merged_model_s3_uri}\")\n",
+    "print(f\"Import job name: {import_job_name}\")\n",
+    "print(f\"Imported model name: {imported_model_name}\")\n",
+    "\n",
+    "create_job_response = bedrock_client.create_model_import_job(\n",
+    "    jobName=import_job_name,\n",
+    "    importedModelName=imported_model_name,\n",
+    "    roleArn=bedrock_import_role_arn,\n",
+    "    modelDataSource={\"s3DataSource\": {\"s3Uri\": merged_model_s3_uri}},\n",
+    ")\n",
+    "\n",
+    "job_arn = create_job_response[\"jobArn\"]\n",
+    "print(f\"Import job ARN: {job_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "oo2c3h2flbi",
+   "metadata": {},
+   "source": [
+    "#### Wait for import job to complete\n",
+    "\n",
+    "The import job typically takes several minutes. We'll poll until it completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nxim9jhqf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "while True:\n",
+    "    response = bedrock_client.get_model_import_job(jobIdentifier=job_arn)\n",
+    "    status = response[\"status\"]\n",
+    "    print(f\"Import job status: {status}\")\n",
+    "\n",
+    "    if status == \"Completed\":\n",
+    "        imported_model_arn = response[\"importedModelArn\"]\n",
+    "        print(f\"\\nImport complete! Model ARN: {imported_model_arn}\")\n",
+    "        break\n",
+    "    elif status == \"Failed\":\n",
+    "        print(f\"\\nImport failed: {response.get('failureMessage', 'Unknown error')}\")\n",
+    "        break\n",
+    "    else:\n",
+    "        time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8kc8muogzmd",
+   "metadata": {},
+   "source": [
+    "#### Test the imported model\n",
+    "\n",
+    "Invoke the imported model using `invoke_model` with the [OpenAI Chat Completion schema](https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html). Bedrock automatically detects the request format based on the payload structure.\n",
+    "\n",
+    "> **Note:** Qwen3 imported models do not support the Converse API ([docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html)). Imported models may also return `ModelNotReadyException` if the model was removed for hardware optimization — the retry config below handles this automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92w8wln257r",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = \"\"\"\n",
+    "Regarding the temporomandibular joint, which statements are true or false: \n",
+    "Is the temporomandibular joint a synovial joint? \n",
+    "Is the articular disc a remnant of the tendon of the medial pterygoid? \n",
+    "Do gliding movements occur in the lower compartment and rotatory movements occur in the upper compartment? \n",
+    "Is the joint capsule thick and tight in the lower part and loose and lax in the upper part? \n",
+    "Does the sphenomandibular ligament act as a false support to the joint and attach to the angle of the mandible?\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "enjzlhf5oz5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botocore.config import Config\n",
+    "\n",
+    "# Configure retries for ModelNotReadyException\n",
+    "retry_config = Config(retries={\"total_max_attempts\": 10, \"mode\": \"standard\"})\n",
+    "bedrock_runtime = boto3.client(\n",
+    "    \"bedrock-runtime\", region_name=sess.boto_region_name, config=retry_config\n",
+    ")\n",
+    "\n",
+    "request_body = json.dumps({\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": prompt,\n",
+    "        }\n",
+    "    ],\n",
+    "    \"max_tokens\": 4096,\n",
+    "    \"temperature\": 0.3,\n",
+    "    \"top_p\": 0.9,\n",
+    "})\n",
+    "\n",
+    "response = bedrock_runtime.invoke_model(\n",
+    "    modelId=imported_model_arn,\n",
+    "    body=request_body,\n",
+    "    accept=\"application/json\",\n",
+    "    contentType=\"application/json\",\n",
+    ")\n",
+    "\n",
+    "response_body = json.loads(response[\"body\"].read())\n",
+    "generated_text = response_body[\"choices\"][0][\"message\"][\"content\"]\n",
+    "print(generated_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9qw8xoy5gun",
+   "metadata": {},
+   "source": [
+    "#### Delete Bedrock imported model\n",
+    "\n",
+    "> **Important:** Bedrock Custom Model Import is billed per [Custom Model Unit (CMU)](https://docs.aws.amazon.com/bedrock/latest/userguide/import-model-calculate-cost.html) in 5-minute windows starting from the first invocation, plus monthly storage costs per CMU. Bedrock scales to zero after 5 minutes of inactivity, but **delete the imported model when you're done** to stop storage charges. See [Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for current rates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bk2dmvavb66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bedrock_client.delete_imported_model(modelIdentifier=imported_model_name)\n",
+    "print(f\"Deleted imported model: {imported_model_name}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/config.py
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/config.py
@@ -1,0 +1,1 @@
+BASE_MODEL_ID = "huggingface-reasoning-qwen3-8b"


### PR DESCRIPTION
## Summary
- Add `config.py` for centralized base model configuration (`huggingface-reasoning-qwen3-8b`), replacing hardcoded Qwen 2.5 7B references across all notebooks
- Add new Bedrock Custom Model Import deployment notebook (4a) as a serverless alternative to the SageMaker Endpoint deployment (4)