### PR TITLE
lab1: simplify benchmark eval and add Bedrock IAM guidance

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-benchmark-evaluation.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-benchmark-evaluation.ipynb
@@ -134,92 +134,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fba1af9a-de3e-4f62-879f-1ce5db65395b",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from sagemaker.serve.model_builder import ModelBuilder\n",
-    "from sagemaker.core.jumpstart.configs import JumpStartConfig\n",
-    "from sagemaker.train.configs import Compute\n",
-    "\n",
-    "base_mpg_name = f\"{base_model_id}-base-mpg\"\n",
-    "\n",
-    "# Step 1: Create model package group\n",
-    "sm_client.create_model_package_group(\n",
-    "    ModelPackageGroupName=base_mpg_name,\n",
-    "    ModelPackageGroupDescription=f\"Base model package group for {base_model_id}\"\n",
-    ")\n",
-    "print(f\"Created model package group: {base_mpg_name}\")\n",
-    "\n",
-    "# Step 2: Use JumpStartConfig to resolve model artifacts automatically\n",
-    "jumpstart_config = JumpStartConfig(model_id=base_model_id)\n",
-    "model_builder = ModelBuilder.from_jumpstart_config(\n",
-    "    jumpstart_config=jumpstart_config,\n",
-    "    compute=Compute(instance_type=\"ml.g5.12xlarge\"),\n",
-    "    sagemaker_session=sess,\n",
-    "    role_arn=role,\n",
-    ")\n",
-    "\n",
-    "# Step 3: Register the base model as a model package\n",
-    "response = model_builder.register(\n",
-    "    model_package_group_name=base_mpg_name,\n",
-    "    content_types=[\"application/json\"],\n",
-    "    response_types=[\"application/json\"],\n",
-    "    inference_instances=[\"ml.g5.12xlarge\"],\n",
-    "    approval_status=\"Approved\",\n",
-    ")\n",
-    "print(f\"Base Model Package ARN: {response}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e31558ae-3c74-4d52-a3a2-22c4926871bb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# # Step 1: Delete all model packages in the group\n",
-    "# pkgs = sm_client.list_model_packages(ModelPackageGroupName=base_mpg_name)\n",
-    "# for pkg in pkgs['ModelPackageSummaryList']:\n",
-    "#     sm_client.delete_model_package(ModelPackageName=pkg['ModelPackageArn'])\n",
-    "#     print(f\"Deleted: {pkg['ModelPackageArn']}\")\n",
-    "\n",
-    "# # Step 2: Delete the group\n",
-    "# sm_client.delete_model_package_group(ModelPackageGroupName=base_mpg_name)\n",
-    "# print(f\"Deleted group: {base_mpg_name}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2be05975-de6f-4f54-9ae9-904462afd21a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Get model package group ARN\n",
-    "mpg_response = sm_client.describe_model_package_group(\n",
-    "    ModelPackageGroupName=base_mpg_name\n",
-    ")\n",
-    "base_model_package_group_arn = mpg_response['ModelPackageGroupArn']\n",
-    "\n",
-    "# Get latest model package ARN\n",
-    "pkg_response = sm_client.list_model_packages(\n",
-    "    ModelPackageGroupName=base_mpg_name,\n",
-    "    SortBy='CreationTime',\n",
-    "    SortOrder='Descending',\n",
-    "    MaxResults=1\n",
-    ")\n",
-    "base_model_package_arn = pkg_response['ModelPackageSummaryList'][0]['ModelPackageArn']\n",
-    "\n",
-    "print(f\"Base Model Group ARN: {base_model_package_group_arn}\")\n",
-    "print(f\"Base Model Package ARN: {base_model_package_arn}\")\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "a4",
    "metadata": {},
@@ -270,7 +184,13 @@
    "cell_type": "markdown",
    "id": "a5",
    "metadata": {},
-   "source": "---\n\n## 3. Run benchmark evaluation\n\nWe run two separate benchmark evaluations — one for the fine-tuned model and one for the base model — then compare the results."
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Run benchmark evaluation\n",
+    "\n",
+    "We run two separate benchmark evaluations — one for the fine-tuned model and one for the base model — then compare the results."
+   ]
   },
   {
    "cell_type": "code",
@@ -279,6 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Evaluate the fine-tuned model\n",
     "evaluator = BenchMarkEvaluator(\n",
     "    benchmark=SELECTED_BENCHMARK,\n",
     "    model=fine_tuned_model_package_arn,\n",
@@ -291,14 +212,12 @@
     "execution = evaluator.evaluate()\n",
     "#execution.wait()\n",
     "\n",
-    "\n",
+    "# Evaluate the base model using the JumpStart model ID directly\n",
     "base_evaluator = BenchMarkEvaluator(\n",
     "    benchmark=SELECTED_BENCHMARK,\n",
-    "    model=base_model_package_arn,\n",
-    "    model_package_group=base_model_package_group_arn,\n",
+    "    model=base_model_id,\n",
     "    base_eval_name='base-model-sft',\n",
     "    s3_output_path=output_path_base,\n",
-    "    evaluate_base_model=False,\n",
     ")\n",
     "\n",
     "execution_base = base_evaluator.evaluate()\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-evaluation.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/3-evaluation.ipynb
@@ -22,11 +22,14 @@
   },
   {
    "cell_type": "code",
-   "id": "59k2cmvmc",
-   "source": "%load_ext autoreload\n%autoreload 2",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "59k2cmvmc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -42,6 +45,22 @@
    "metadata": {},
    "source": [
     "#### Setup and dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i8ax4lmsfig",
+   "metadata": {},
+   "source": [
+    "> **Important — IAM setup for Bedrock evaluation:** \n",
+    "\n",
+    "The evaluation job uses Amazon Bedrock for LLM-as-Judge scoring. \n",
+    "\n",
+    "Your SageMaker execution role must include `bedrock.amazonaws.com` as a trusted entity in its trust policy. Without this, the pipeline will appear to start normally but the `EvaluateCustomModelMetrics` step will fail. \n",
+    "You will see an error by inspecting the pipeline execution in the SageMaker console (Pipelines > Executions > select the failed step). \n",
+    "\n",
+    "\n",
+    "See [Amazon Bedrock permissions setup](https://docs.aws.amazon.com/bedrock/latest/userguide/judge-service-roles.html) for instructions on updating your role's trust relationship."
    ]
   },
   {
@@ -92,7 +111,16 @@
    "id": "b03f3aa4",
    "metadata": {},
    "outputs": [],
-   "source": "from sagemaker.ai_registry.dataset import DataSet\nfrom sagemaker.core.resources import ModelPackageGroup\nfrom config import BASE_MODEL_ID\n\nbase_model_id = BASE_MODEL_ID\n\nmodel_package_group_name = f\"{base_model_id}-sft-mpg\"\nmodel_package_version = \"1\""
+   "source": [
+    "from sagemaker.ai_registry.dataset import DataSet\n",
+    "from sagemaker.core.resources import ModelPackageGroup\n",
+    "from config import BASE_MODEL_ID\n",
+    "\n",
+    "base_model_id = BASE_MODEL_ID\n",
+    "\n",
+    "model_package_group_name = f\"{base_model_id}-sft-mpg\"\n",
+    "model_package_version = \"1\""
+   ]
   },
   {
    "cell_type": "code",
@@ -265,6 +293,14 @@
    "outputs": [],
    "source": [
     "execution = evaluator.evaluate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "w1omtqwe1dn",
+   "metadata": {},
+   "source": [
+    "> **Tip:** The evaluation pipeline takes ~15-20 minutes. You can monitor progress in the SageMaker console under **Pipelines > Executions**. If the `EvaluateCustomModelMetrics` step fails with an \"access denied\" error, check that your execution role's trust policy includes `bedrock.amazonaws.com` (see the prerequisites note above)."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Remove manual base model package registration steps from the benchmark evaluation notebook — use the JumpStart model ID directly for base model evaluation, simplifying the workflow
  - This aligns with the SDK example code: https://sagemaker.readthedocs.io/en/stable/v3-examples/model-customization-examples/benchmark_demo.html
- Add IAM trust policy prerequisites note for Bedrock LLM-as-Judge scoring (common failure point)
- Add pipeline monitoring tip with troubleshooting guidance for the evaluation step