### PR TITLE
Modified hyperparam name from lr_warmup_ratio to lr_warmup_steps_ratio

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
@@ -270,7 +270,7 @@
     "trainer.hyperparameters.learning_rate = 0.0001\n",
     "trainer.hyperparameters.global_batch_size = 64\n",
     "trainer.hyperparameters.max_epochs = 1\n",
-    "trainer.hyperparameters.lr_warmup_ratio = 0.1"
+    "trainer.hyperparameters.lr_warmup_steps_ratio = 0.1"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* In Lab 1, step 2, one Hyperparam has a wrong name

*Description of changes:* Modified hyperparam name from `lr_warmup_ratio` to `lr_warmup_steps_ratio`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
