### PR TITLE
Lab 1: add workshop notice for Bedrock CMI in event accounts

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4a-deployment-bedrock.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4a-deployment-bedrock.ipynb
@@ -13,7 +13,8 @@
     "\n",
     "**When to use this vs. Lab 4 (SageMaker Endpoint):**\n",
     "- **Bedrock Custom Model Import (this notebook):** Fully serverless, no infrastructure to manage, billed per Custom Model Unit in 5-minute windows with scale-to-zero. Best when you want simplicity and don't need fine-grained control over the hosting environment.\n",
-    "- **SageMaker Endpoint (Lab 4):** Dedicated GPU instances, full control over instance type, scaling policies, and serving configuration. Best when you need predictable latency or cost optimization at high throughput."
+    "- **SageMaker Endpoint (Lab 4):** Dedicated GPU instances, full control over instance type, scaling policies, and serving configuration. Best when you need predictable latency or cost optimization at high throughput.\n",
+    "\n"
    ]
   },
   {
@@ -21,6 +22,16 @@
    "id": "d2b6949b",
    "metadata": {},
    "source": [
+    "***\n",
+    "\n",
+    "\n",
+    "> ⚠️ **AWS Event participants — read this first**\n",
+    ">\n",
+    "> Bedrock Custom Model Import jobs (`bedrock:CreateModelImportJob`) **cannot be run in AWS-managed event accounts** (Workshop Studio) due to service policy restrictions. If you are at an AWS-run workshop, skip the hands-on portion of this notebook and use it as a reference.\n",
+    ">\n",
+    "> To run this notebook, use your own AWS account with the IAM permissions described below.\n",
+    "\n",
+    "\n",
     "***"
    ]
   },


### PR DESCRIPTION
## Summary
- Adds a callout to `lab-1-supervised-fine-tuning/4a-deployment-bedrock.ipynb` warning AWS-managed event (Workshop Studio) participants that `bedrock:CreateModelImportJob` is blocked in those accounts
- Directs event participants to use their own AWS account for the hands-on portion, or treat the notebook as reference
