### PR TITLE
fix(task_05_fmops): clean up accidental commit fc3ffe1

### DIFF
--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.00_fmops_examples.ipynb
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.00_fmops_examples.ipynb
@@ -35,36 +35,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -r ./scripts/requirements.txt --upgrade --quiet"
+    "%pip install -r ./scripts/requirements.txt --upgrade --quiet\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': 'ok', 'restart': True}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython import get_ipython\n",
     "get_ipython().kernel.do_shutdown(True)"
@@ -81,32 +59,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/shapes/shapes.py:8920: SyntaxWarning: invalid escape sequence '\\|'\n",
-      "  domain: The machine learning domain of the model and its components. Valid Values: COMPUTER_VISION \\| NATURAL_LANGUAGE_PROCESSING \\| MACHINE_LEARNING\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/shapes/shapes.py:9872: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  schedule_expression: A cron expression that describes details about the monitoring schedule. The supported cron expressions are:   If you want to set the job to start every hour, use the following:  Hourly: cron(0 \\* ? \\* \\* \\*)    If you want to start the job daily:  cron(0 [00-23] ? \\* \\* \\*)    If you want to run the job one time, immediately, use the following keyword:  NOW    For example, the following are valid cron expressions:   Daily at noon UTC: cron(0 12 ? \\* \\* \\*)    Daily at midnight UTC: cron(0 0 ? \\* \\* \\*)    To support running every 6, 12 hours, the following are also supported:  cron(0 [00-23]/[01-24] ? \\* \\* \\*)  For example, the following are valid cron expressions:   Every 12 hours, starting at 5pm UTC: cron(0 17/12 ? \\* \\* \\*)    Every two hours starting at midnight: cron(0 0/2 ? \\* \\* \\*)       Even though the cron expression is set to start at 5PM UTC, note that there could be a delay of 0-20 minutes from the actual requested time to run the execution.    We recommend that if you would like a daily schedule, you do not provide this parameter. Amazon SageMaker AI will pick a time for running every day.    You can also specify the keyword NOW to run the monitoring job immediately, one time, without recurring.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/shapes/shapes.py:10256: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  group_patterns: A list of Amazon Web Services IAM Identity Center group patterns that should be assigned to the specified role. Group patterns support wildcard matching using \\*.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/shapes/shapes.py:10272: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  assigned_group_patterns: A list of Amazon Web Services IAM Identity Center group patterns that can access the SageMaker Partner AI App. Group names support wildcard matching using \\*. An empty list indicates the app will not use Identity Center group features. All groups specified in RoleGroupAssignments must match patterns in this list.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/shapes/shapes.py:13024: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  resource_retained_billable_time_in_seconds: The billable time in seconds used by the warm pool. Billable time refers to the absolute wall-clock time. Multiply ResourceRetainedBillableTimeInSeconds by the number of instances (InstanceCount) in your training cluster to get the total compute time SageMaker bills you if you run warm pool training. The formula is as follows: ResourceRetainedBillableTimeInSeconds \\* InstanceCount.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py:24963: SyntaxWarning: invalid escape sequence '\\|'\n",
-      "  task: The machine learning task your model package accomplishes. Common machine learning tasks include object detection and image classification. The following tasks are supported by Inference Recommender: \"IMAGE_CLASSIFICATION\" \\| \"OBJECT_DETECTION\" \\| \"TEXT_GENERATION\" \\|\"IMAGE_SEGMENTATION\" \\| \"FILL_MASK\" \\| \"CLASSIFICATION\" \\| \"REGRESSION\" \\| \"OTHER\". Specify \"OTHER\" if none of the tasks listed fit your use case.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py:35291: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  billable_time_in_seconds: The billable time in seconds. Billable time refers to the absolute wall-clock time. Multiply BillableTimeInSeconds by the number of instances (InstanceCount) in your training cluster to get the total compute time SageMaker bills you if you run distributed training. The formula is as follows: BillableTimeInSeconds \\* InstanceCount . You can calculate the savings from using managed spot training using the formula (1 - BillableTimeInSeconds / TrainingTimeInSeconds) \\* 100. For example, if BillableTimeInSeconds is 100 and TrainingTimeInSeconds is 500, the savings is 80%.\n",
-      "/home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py:37003: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  max_payload_in_mb: The maximum allowed size of the payload, in MB. A payload is the data portion of a record (without metadata). The value in MaxPayloadInMB must be greater than, or equal to, the size of a single record. To estimate the size of a record in MB, divide the size of your dataset by the number of records. To ensure that the records fit within the maximum payload size, we recommend using a slightly larger value. The default value is 6 MB.  The value of MaxPayloadInMB cannot be greater than 100 MB. If you specify the MaxConcurrentTransforms parameter, the value of (MaxConcurrentTransforms \\* MaxPayloadInMB) also cannot exceed 100 MB. For cases where the payload might be arbitrarily large and is transmitted using HTTP chunked encoding, set the value to 0. This feature works only in supported algorithms. Currently, Amazon SageMaker built-in algorithms do not support HTTP chunked encoding.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import json\n",
@@ -144,33 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 20:30:47] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 20:30:47]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757019;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757020;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
-      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ubuntu/.config/sagemaker/config.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sagemaker_session = Session()\n",
     "role = get_execution_role(sagemaker_session, use_default=True)\n",
@@ -191,17 +122,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker-ap-northeast-1-364430515305\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bucket_name = sagemaker_session.default_bucket()\n",
     "print(bucket_name)\n",
@@ -214,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,57 +155,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MLflow integration is crucial for experiment tracking and management. \n",
-    "\n",
-    "**Update the ARN for the MLflow tracking server.**"
+    "MLflow integration is crucial for experiment tracking and management.\n\nThe cell below auto-discovers the MLflow tracking server named `genai-mlflow-tracker` (the default in this workshop's environment). If you have a different setup, set `mlflow_tracking_server_arn` manually with your tracking server ARN."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example requires a SageMaker with MLflow tracking server to track experiments and manage model artifacts. To create your own tracking server please refer to the [SageMaker documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html). Once you have created your tracking server, please copy the tracking server ARN to the `mlflow_tracking server_arn` variable in the cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Summaries': [{'Arn': 'arn:aws:sagemaker:ap-northeast-1:364430515305:mlflow-app/app-CVJK6FJPTNDJ',\n",
-       "   'Name': 'tokyo-mlflow',\n",
-       "   'Status': 'Created',\n",
-       "   'CreationTime': datetime.datetime(2026, 4, 16, 20, 29, 11, tzinfo=tzlocal()),\n",
-       "   'LastModifiedTime': datetime.datetime(2026, 4, 16, 20, 33, 54, 578000, tzinfo=tzlocal()),\n",
-       "   'MlflowVersion': '3.4.0'}],\n",
-       " 'ResponseMetadata': {'RequestId': '914f5bf1-31b0-4e12-8211-e3cd4f94343c',\n",
-       "  'HTTPStatusCode': 200,\n",
-       "  'HTTPHeaders': {'x-amzn-requestid': '914f5bf1-31b0-4e12-8211-e3cd4f94343c',\n",
-       "   'strict-transport-security': 'max-age=47304000; includeSubDomains',\n",
-       "   'x-frame-options': 'DENY',\n",
-       "   'content-security-policy': \"frame-ancestors 'none'\",\n",
-       "   'cache-control': 'no-cache, no-store, must-revalidate',\n",
-       "   'x-content-type-options': 'nosniff',\n",
-       "   'content-type': 'application/x-amz-json-1.1',\n",
-       "   'content-length': '229',\n",
-       "   'date': 'Thu, 16 Apr 2026 20:40:33 GMT'},\n",
-       "  'RetryAttempts': 0}}"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response = boto3.client('sagemaker').list_mlflow_apps()\n",
-    "mlflow_app_arn = response['Summaries'][0]['Arn']\n",
-    "\n",
-    "r = boto3.client('sagemaker').describe_mlflow_app(Arn=mlflow_app_arn)\n",
-    "response"
+    "This example requires a SageMaker with MLflow tracking server to track experiments and manage model artifacts. To create your own tracking server please refer to the [SageMaker documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html). The cell below first attempts to auto-resolve the tracking server ARN by name. If no server is found, set `mlflow_tracking_server_arn` manually."
    ]
   },
   {
@@ -291,19 +171,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlflow_tracking_server_arn = \"arn:aws:sagemaker:ap-northeast-1:364430515305:mlflow-app/app-CVJK6FJPTNDJ\" # ENTER YOUR ARN HERE\n",
+    "mlflow_tracking_server_arn = \"\"  # Manual fallback if auto-discovery below fails\n",
     "\n",
-    "# try:\n",
-    "#     response = boto3.client('sagemaker').describe_mlflow_tracking_server(\n",
-    "#         TrackingServerName='genai-mlflow-tracker'\n",
-    "#     )\n",
-    "#     mlflow_tracking_server_arn = response['TrackingServerArn']\n",
-    "#     print(f\"MLflow Tracking Server ARN: {mlflow_tracking_server_arn}\")\n",
-    "# except botocore.exceptions.ClientError:\n",
-    "#     print(\"No MLflow Tracking Server Found, please input a value for mlflow_tracking_server_arn\")\n",
-    "\n",
-    "# os.environ[\"mlflow_tracking_server_arn\"] = mlflow_tracking_server_arn\n",
-    "\n"
+    "try:\n",
+    "    response = boto3.client('sagemaker').describe_mlflow_tracking_server(\n",
+    "        TrackingServerName='genai-mlflow-tracker'\n",
+    "    )\n",
+    "    mlflow_tracking_server_arn = response['TrackingServerArn']\n",
+    "    print(f\"MLflow Tracking Server ARN: {mlflow_tracking_server_arn}\")\n",
+    "except botocore.exceptions.ClientError:\n",
+    "    print(\"No MLflow Tracking Server Found, please input a value for mlflow_tracking_server_arn\")\n"
    ]
   },
   {
@@ -328,17 +205,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "using image to host: 763104351884.dkr.ecr.ap-northeast-1.amazonaws.com/djl-inference:0.33.0-lmi15.0.0-cu128\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "inference_image_uri = f\"763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.33.0-lmi15.0.0-cu128\"\n",
     "print(f\"using image to host: {inference_image_uri}\")"
@@ -354,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,35 +252,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 20:40:45] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 20:40:45]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757031;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757032;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<Experiment: artifact_location='s3://sagemaker-ap-northeast-1-364430515305/0', creation_time=1776371612849, experiment_id='0', last_update_time=1776371612849, lifecycle_stage='active', name='Default', tags={}>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Initialize MLFlow tracking data...\n",
     "mlflow.set_tracking_uri(mlflow_tracking_server_arn)\n",
@@ -422,148 +265,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 20:40:47] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 20:40:47]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757037;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757038;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757043;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757044;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757049;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757050;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
-      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ubuntu/.config/sagemaker/config.yaml\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Creating model resource.                                            <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">resources.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#22771\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">22771</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Creating model resource.                                            \u001b]8;id=3757057;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\u001b\\\u001b[2mresources.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757058;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#22771\u001b\\\u001b[2m22771\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> No region provided. Using default region.                                 <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py#356\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">356</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m No region provided. Using default region.                                 \u001b]8;id=3757065;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757066;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py#356\u001b\\\u001b[2m356\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Runs on sagemaker prod, region:ap-northeast-<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>                             <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utils.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py#370\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">370</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Runs on sagemaker prod, region:ap-northeast-\u001b[1;36m1\u001b[0m                             \u001b]8;id=3757072;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py\u001b\\\u001b[2mutils.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757073;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/utils/utils.py#370\u001b\\\u001b[2m370\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=3757078;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757079;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 20:40:48] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Creating endpoint_config resource.                                  <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">resources.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#11602\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">11602</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 20:40:48]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Creating endpoint_config resource.                                  \u001b]8;id=3757085;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\u001b\\\u001b[2mresources.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757086;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#11602\u001b\\\u001b[2m11602\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Creating endpoint resource.                                         <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">resources.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#10735\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">10735</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Creating endpoint resource.                                         \u001b]8;id=3757092;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py\u001b\\\u001b[2mresources.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=3757093;file:///home/ubuntu/pipelines/.venv/lib/python3.12/site-packages/sagemaker/core/resources.py#10735\u001b\\\u001b[2m10735\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-------"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with mlflow.start_run(run_name=\"example_model_deployment_new\"):\n",
     "    deployment_start_time = time.time()\n",

--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.01_fine-tuning-pipeline.ipynb
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.01_fine-tuning-pipeline.ipynb
@@ -52,41 +52,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip uninstall -yq sagemaker sagemaker-core sagemaker-train sagemaker-serve sagemaker-mlops pynvml\n",
-    "# %pip cache purge\n",
-    "# %pip install -r ./scripts/requirements.txt --upgrade --quiet"
+    "%pip uninstall -yq sagemaker sagemaker-core sagemaker-train sagemaker-serve sagemaker-mlops pynvml\n",
+    "%pip cache purge\n",
+    "%pip install -r ./scripts/requirements.txt --upgrade --quiet\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': 'ok', 'restart': True}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# from IPython import get_ipython\n",
-    "# get_ipython().kernel.do_shutdown(True)"
+    "from IPython import get_ipython\n",
+    "get_ipython().kernel.do_shutdown(True)\n"
    ]
   },
   {
@@ -100,33 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:40] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:40]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=11295442;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295443;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
-      "sagemaker.config INFO - Not applying SDK defaults from location: /home/ubuntu/.config/sagemaker/config.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import boto3\n",
@@ -156,30 +110,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:42] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:42]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=11295448;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295449;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sagemaker_session = Session()\n",
     "role = get_execution_role(sagemaker_session, use_default=True)\n",
     "instance_type = \"ml.m5.xlarge\"\n",
-    "pipeline_name = \"qwen3-finetune-pipeline-tokyo\"\n",
+    "pipeline_name = \"qwen3-finetune-pipeline\"\n",
     "bucket_name = sagemaker_session.default_bucket()\n",
     "default_prefix = sagemaker_session.default_bucket_prefix\n",
     "if default_prefix:\n",
@@ -202,37 +140,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MLflow integration is crucial for experiment tracking and management. **Update the ARN for the MLflow tracking server.**\n",
-    "\n",
-    "mlflow_arn: The ARN for the MLflow tracking server. You can get this ARN from SageMaker Studio UI. This allows the pipeline to log metrics, parameters, and artifacts to a central location."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This example requires a SageMaker with MLflow tracking server to track experiments and manage model artifacts. To create your own tracking server please refer to the [SageMaker documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html). Once you have created your tracking server, please copy the tracking server ARN to the `mlflow_tracking server_arn` variable in the cell below."
+    "MLflow integration is crucial for experiment tracking and management. The cell below auto-resolves the MLflow tracking server ARN by name (`genai-mlflow-tracker`, the default in the workshop environment). If you have a different setup, set `mlflow_tracking_server_arn` manually."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlflow_tracking_server_arn =  \"arn:aws:sagemaker:ap-northeast-1:364430515305:mlflow-app/app-CVJK6FJPTNDJ\"  # ENTER YOUR ARN HERE\n",
+    "mlflow_tracking_server_arn = \"\"  # Manual fallback if auto-discovery below fails\n",
     "\n",
-    "# try:\n",
-    "#     response = boto3.client('sagemaker').describe_mlflow_tracking_server(\n",
-    "#         TrackingServerName='genai-mlflow-tracker'\n",
-    "#     )\n",
-    "#     mlflow_tracking_server_arn = response['TrackingServerArn']\n",
-    "#     print(f\"MLflow Tracking Server ARN: {mlflow_tracking_server_arn}\")\n",
-    "# except ClientError:\n",
-    "#     print(\"No MLflow Tracking Server Found, please input a value for mlflow_tracking_server_arn\")\n",
+    "try:\n",
+    "    response = boto3.client('sagemaker').describe_mlflow_tracking_server(\n",
+    "        TrackingServerName='genai-mlflow-tracker'\n",
+    "    )\n",
+    "    mlflow_tracking_server_arn = response['TrackingServerArn']\n",
+    "    print(f\"MLflow Tracking Server ARN: {mlflow_tracking_server_arn}\")\n",
+    "except ClientError:\n",
+    "    print(\"No MLflow Tracking Server Found, please input a value for mlflow_tracking_server_arn\")\n",
     "\n",
     "os.environ[\"mlflow_tracking_server_arn\"] = mlflow_tracking_server_arn\n",
-    "os.environ[\"pipeline_name\"] = pipeline_name"
+    "os.environ[\"pipeline_name\"] = pipeline_name\n"
    ]
   },
   {
@@ -244,17 +173,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting config.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile config.yaml\n",
     "SchemaVersion: '1.0'\n",
@@ -275,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,97 +213,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading model  Qwen/Qwen3-4B-Instruct-2507\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b16699cc9a9744ad949abb2a41f585a9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Fetching 13 files:   0%|          | 0/13 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model Qwen/Qwen3-4B-Instruct-2507 downloaded under ../models/Qwen_Qwen3-4B-Instruct-2507\n",
-      "Beginning Model Upload to s3://sagemaker-ap-northeast-1-364430515305/models/Qwen_Qwen3-4B-Instruct-2507...\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:45] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> Found credentials from IAM Role:                                   <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">credentials.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1171</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         AWS-EC2-AdminAccess-Instance-Profile                               <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:45]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m Found credentials from IAM Role:                                   \u001b]8;id=11295454;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py\u001b\\\u001b[2mcredentials.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295455;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/botocore/credentials.py#1171\u001b\\\u001b[2m1171\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         AWS-EC2-AdminAccess-Instance-Profile                               \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 27 files in ../models/Qwen_Qwen3-4B-Instruct-2507\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/tokenizer.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/model-00001-of-00003.safetensors (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/vocab.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/README.md (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/config.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/model-00003-of-00003.safetensors (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/model-00002-of-00003.safetensors (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/merges.txt (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/LICENSE (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/generation_config.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.gitattributes (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/tokenizer_config.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/model.safetensors.index.json (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/.gitignore (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/generation_config.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/tokenizer.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/tokenizer_config.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/.gitattributes.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/config.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/LICENSE.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/merges.txt.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/model-00003-of-00003.safetensors.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/model.safetensors.index.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/model-00002-of-00003.safetensors.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/README.md.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/vocab.json.metadata (file exists in S3)\n",
-      "Skipping models/Qwen_Qwen3-4B-Instruct-2507/.cache/huggingface/download/model-00001-of-00003.safetensors.metadata (file exists in S3)\n",
-      "\n",
-      "Upload Summary:\n",
-      "  - Uploaded: 0 files\n",
-      "  - Skipped: 27 files\n",
-      "  - Failed: 0 files\n",
-      "Model successfully uploaded to: \n",
-      " s3://sagemaker-ap-northeast-1-364430515305/models/Qwen_Qwen3-4B-Instruct-2507\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from huggingface_hub import snapshot_download\n",
     "\n",
@@ -520,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,19 +433,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Fetched defaults config from location: /home/ubuntu/pipelines/generative-ai-on-amazon-sagemaker/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops\n",
-      "Training config uploaded to:\n",
-      "s3://sagemaker-ap-northeast-1-364430515305/training_config/Qwen_Qwen3-4B-Instruct-2507/config/args.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sagemaker.core.s3 import S3Uploader\n",
     "\n",
@@ -649,17 +474,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found Guardrail 5k3e0jar1n6t:DRAFT\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from steps import pipeline_utils\n",
     "guardrail_id, guardrail_version = pipeline_utils.get_or_create_guardrail()"
@@ -667,23 +484,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:49] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> PyTorch version <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.11</span>.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span> available.                                         <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/datasets/config.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">config.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/datasets/config.py#54\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">54</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:49]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m PyTorch version \u001b[1;36m2.11\u001b[0m.\u001b[1;36m0\u001b[0m available.                                         \u001b]8;id=11295462;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/datasets/config.py\u001b\\\u001b[2mconfig.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295463;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/datasets/config.py#54\u001b\\\u001b[2m54\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from steps import (\n",
     "    preprocess_step,\n",
@@ -808,467 +611,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:50] </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> SageMaker Python SDK will collect telemetry to help us better <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">telemetry_logging.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py#103\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">103</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         understand our user's needs, diagnose issues, and deliver     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         additional features.                                          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         To opt out of telemetry, please disable via TelemetryOptOut   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         parameter in SDK defaults config. For more information, refer <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         to                                                            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #0069ff; text-decoration-color: #0069ff; text-decoration: underline\">https://sagemaker.readthedocs.io/en/stable/overview.html#conf</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #0069ff; text-decoration-color: #0069ff; text-decoration: underline\">iguring-and-using-defaults-with-the-sagemaker-python-sdk.</span>     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:50]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m SageMaker Python SDK will collect telemetry to help us better \u001b]8;id=11295470;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py\u001b\\\u001b[2mtelemetry_logging.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295471;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py#103\u001b\\\u001b[2m103\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         understand our user's needs, diagnose issues, and deliver     \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         additional features.                                          \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         To opt out of telemetry, please disable via TelemetryOptOut   \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         parameter in SDK defaults config. For more information, refer \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         to                                                            \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         \u001b[4;38;2;0;105;255mhttps://sagemaker.readthedocs.io/en/stable/overview.html#conf\u001b[0m \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         \u001b[4;38;2;0;105;255miguring-and-using-defaults-with-the-sagemaker-python-sdk.\u001b[0m     \u001b[2m                        \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.Dependencies\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:02:53,095 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:02:53,169 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:02:53,382 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmpoonl5ult/requirements.txt'\n",
-      "2026-04-16 23:02:53,424 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n",
-      "2026-04-16 23:02:53,429 sagemaker.remote_function INFO     Copied user workspace to '/tmp/tmp5_45fr60/temp_workspace/sagemaker_remote_function_workspace'\n",
-      "2026-04-16 23:02:53,447 sagemaker.remote_function INFO     Successfully created workdir archive at '/tmp/tmp5_45fr60/workspace.zip'\n",
-      "2026-04-16 23:02:53,509 sagemaker.remote_function INFO     Successfully uploaded workdir to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/sm_rf_user_ws/2026-04-16-23-02-50-385/workspace.zip'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:53] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:53]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295478;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295479;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:02:56,299 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:02:56,369 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:02:56,433 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmpvjv47jpd/requirements.txt'\n",
-      "2026-04-16 23:02:56,465 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:56] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:56]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295484;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295485;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.Dependencies\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:02:58,943 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:02:59,038 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:02:59,110 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmpodl5smxx/requirements.txt'\n",
-      "2026-04-16 23:02:59,146 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:02:59] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:02:59]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295490;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295491;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:01,633 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:03:01,700 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:03:01,766 sagemaker.remote_function INFO     Copied dependencies file at './eval/requirements.txt' to '/tmp/tmp5ygod_s2/requirements.txt'\n",
-      "2026-04-16 23:03:01,803 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:03:01] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:03:01]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295496;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295497;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:04,299 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:03:04,400 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:03:04,468 sagemaker.remote_function INFO     Copied dependencies file at './eval/requirements.txt' to '/tmp/tmpvhcv6_ke/requirements.txt'\n",
-      "2026-04-16 23:03:04,501 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:03:04] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:03:04]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295502;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295503;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.Dependencies\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.IncludeLocalWorkDir\n",
-      "sagemaker.config INFO - Applied value from config key = SageMaker.PythonSDK.Modules.RemoteFunction.CustomFileFilter.IgnoreNamePatterns\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:06,987 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-02-50-385/function\n",
-      "2026-04-16 23:03:07,064 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-02-50-385/arguments\n",
-      "2026-04-16 23:03:07,138 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmptaptkd52/requirements.txt'\n",
-      "2026-04-16 23:03:07,170 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-02-50-385/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:03:07] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:03:07]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295508;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295509;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:07,676 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:07,748 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:07,966 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmpbtcyfph0/requirements.txt'\n",
-      "2026-04-16 23:03:08,004 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/DataPreprocessing/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n",
-      "2026-04-16 23:03:08,009 sagemaker.remote_function INFO     Copied user workspace to '/tmp/tmp2gc8f8c1/temp_workspace/sagemaker_remote_function_workspace'\n",
-      "2026-04-16 23:03:08,026 sagemaker.remote_function INFO     Successfully created workdir archive at '/tmp/tmp2gc8f8c1/workspace.zip'\n",
-      "2026-04-16 23:03:08,108 sagemaker.remote_function INFO     Successfully uploaded workdir to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/sm_rf_user_ws/2026-04-16-23-03-07-676/workspace.zip'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:03:08] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:03:08]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295514;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295515;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:08,113 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:08,179 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:08,252 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmp_pofgloc/requirements.txt'\n",
-      "2026-04-16 23:03:08,283 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelFineTuning/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295520;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295521;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:08,287 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:08,366 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:08,443 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmpy_ci5zsz/requirements.txt'\n",
-      "2026-04-16 23:03:08,475 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelDeploy/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295526;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295527;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:08,479 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:08,554 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:08,624 sagemaker.remote_function INFO     Copied dependencies file at './eval/requirements.txt' to '/tmp/tmp82zcooax/requirements.txt'\n",
-      "2026-04-16 23:03:08,660 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QuantitativeModelEvaluation/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295532;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295533;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:08,665 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:08,733 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:08,806 sagemaker.remote_function INFO     Copied dependencies file at './eval/requirements.txt' to '/tmp/tmpt3bw_ftp/requirements.txt'\n",
-      "2026-04-16 23:03:08,841 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/QualitativeModelEvaluation/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295538;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295539;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-04-16 23:03:08,845 sagemaker.remote_function INFO     Uploading serialized function code to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-03-07-676/function\n",
-      "2026-04-16 23:03:08,915 sagemaker.remote_function INFO     Uploading serialized function arguments to s3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-03-07-676/arguments\n",
-      "2026-04-16 23:03:08,986 sagemaker.remote_function INFO     Copied dependencies file at './scripts/requirements.txt' to '/tmp/tmp3x0l4fo0/requirements.txt'\n",
-      "2026-04-16 23:03:09,025 sagemaker.remote_function INFO     Successfully uploaded dependencies and pre execution scripts to 's3://sagemaker-ap-northeast-1-364430515305/qwen3-finetune-pipeline-tokyo/ModelRegistration/2026-04-16-23-03-07-676/pre_exec_script_and_dependencies'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/16/26 23:03:09] </span><span style=\"color: #d7af00; text-decoration-color: #d7af00; font-weight: bold\">WARNING </span> Popping out <span style=\"color: #008700; text-decoration-color: #008700\">'TrainingJobName'</span> from the pipeline definition by default <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">utilities.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">480</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         since it will be overridden at pipeline execution time. Please        <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         utilize the PipelineDefinitionConfig to persist this field in the     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         pipeline definition if desired.                                       <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[04/16/26 23:03:09]\u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;215;175;0mWARNING \u001b[0m Popping out \u001b[38;2;0;135;0m'TrainingJobName'\u001b[0m from the pipeline definition by default \u001b]8;id=11295544;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py\u001b\\\u001b[2mutilities.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295545;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/workflow/utilities.py#480\u001b\\\u001b[2m480\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         since it will be overridden at pipeline execution time. Please        \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         utilize the PipelineDefinitionConfig to persist this field in the     \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         pipeline definition if desired.                                       \u001b[2m                \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'PipelineArn': 'arn:aws:sagemaker:ap-northeast-1:364430515305:pipeline/qwen3-finetune-pipeline-tokyo',\n",
-       " 'PipelineVersionId': 3,\n",
-       " 'ResponseMetadata': {'RequestId': '7b9cdabd-1bc6-4e7c-b23e-e709b4ca2620',\n",
-       "  'HTTPStatusCode': 200,\n",
-       "  'HTTPHeaders': {'x-amzn-requestid': '7b9cdabd-1bc6-4e7c-b23e-e709b4ca2620',\n",
-       "   'strict-transport-security': 'max-age=47304000; includeSubDomains',\n",
-       "   'x-frame-options': 'DENY',\n",
-       "   'content-security-policy': \"frame-ancestors 'none'\",\n",
-       "   'cache-control': 'no-cache, no-store, must-revalidate',\n",
-       "   'x-content-type-options': 'nosniff',\n",
-       "   'content-type': 'application/x-amz-json-1.1',\n",
-       "   'content-length': '124',\n",
-       "   'date': 'Thu, 16 Apr 2026 23:03:09 GMT'},\n",
-       "  'RetryAttempts': 0}}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pipeline.upsert(role)"
    ]
@@ -1284,37 +631,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #0069ff; text-decoration-color: #0069ff; font-weight: bold\">INFO    </span> SageMaker Python SDK will collect telemetry to help us better <a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">telemetry_logging.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py#103\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">103</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         understand our user's needs, diagnose issues, and deliver     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         additional features.                                          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         To opt out of telemetry, please disable via TelemetryOptOut   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         parameter in SDK defaults config. For more information, refer <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         to                                                            <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #0069ff; text-decoration-color: #0069ff; text-decoration: underline\">https://sagemaker.readthedocs.io/en/stable/overview.html#conf</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #0069ff; text-decoration-color: #0069ff; text-decoration: underline\">iguring-and-using-defaults-with-the-sagemaker-python-sdk.</span>     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                        </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[1;38;2;0;105;255mINFO    \u001b[0m SageMaker Python SDK will collect telemetry to help us better \u001b]8;id=11295550;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py\u001b\\\u001b[2mtelemetry_logging.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=11295551;file:///home/ubuntu/pipelines/.venv/lib/python3.10/site-packages/sagemaker/core/telemetry/telemetry_logging.py#103\u001b\\\u001b[2m103\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         understand our user's needs, diagnose issues, and deliver     \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         additional features.                                          \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         To opt out of telemetry, please disable via TelemetryOptOut   \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         parameter in SDK defaults config. For more information, refer \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         to                                                            \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         \u001b[4;38;2;0;105;255mhttps://sagemaker.readthedocs.io/en/stable/overview.html#conf\u001b[0m \u001b[2m                        \u001b[0m\n",
-       "\u001b[2;36m                    \u001b[0m         \u001b[4;38;2;0;105;255miguring-and-using-defaults-with-the-sagemaker-python-sdk.\u001b[0m     \u001b[2m                        \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "execution = pipeline.start()"
    ]

--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/args.yaml
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/args.yaml
@@ -1,13 +1,13 @@
 
 # MLflow Config
-mlflow_uri: "arn:aws:sagemaker:ap-northeast-1:364430515305:mlflow-app/app-CVJK6FJPTNDJ"                # The URI for the MLflow tracking server 
-mlflow_experiment_name: "qwen3-finetune-pipeline-tokyo"  # Name of the MLflow experiment for organizing runs
+mlflow_uri: ""  # REPLACE WITH YOUR MLFLOW TRACKING SERVER ARN                # The URI for the MLflow tracking server
+mlflow_experiment_name: "qwen3-finetune-pipeline"  # Name of the MLflow experiment for organizing runs
 
 
-model_id: "s3://sagemaker-ap-northeast-1-364430515305/models/Qwen_Qwen3-4B-Instruct-2507"              # Hugging Face model id, or S3 location of base model
+model_id: "Qwen/Qwen3-4B-Instruct-2507"              # Hugging Face model id, or S3 location of base model
 
-# SageMaker specific parameters 
-output_dir: "/opt/ml/model"                # Path where SageMaker will upload the model 
+# SageMaker specific parameters
+output_dir: "/opt/ml/model"                # Path where SageMaker will upload the model
 train_dataset_path: "/opt/ml/input/data/train/"   # Path where FSx saves train dataset
 test_dataset_path: "/opt/ml/input/data/test/"     # Path where FSx saves test dataset
 

--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/steps/finetune_step.py
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/steps/finetune_step.py
@@ -130,7 +130,7 @@ def train(
                 
                 # Define the compute
                 compute_configs = Compute(
-                    instance_type="ml.g6.2xlarge",
+                    instance_type="ml.g5.2xlarge",
                     instance_count=1,
                     keep_alive_period_in_seconds=3600,
                     volume_size_in_gb=50


### PR DESCRIPTION
## Summary

Closes #254. Restores `task_05_fmops` notebooks and supporting code to a workshop-ready state by reverting the regressions introduced in fc3ffe17 while preserving the legitimate f-string fix to `steps/pipeline_utils.py`.

This is a chirurgical fix rather than a pure `git revert` of fc3ffe17 because that commit mixed three categories of changes:
1. Regressions (hardcoded perso ARNs, executed outputs, `g6` instance type mismatch, `-tokyo` rename) — reverted
2. A new file `args.yaml` that the workshop now depends on — kept and sanitized
3. A genuine f-string syntax fix in `pipeline_utils.py` — kept as-is

## Changes by file

### `steps/finetune_step.py`
- Revert `instance_type` from `ml.g6.2xlarge` to `ml.g5.2xlarge` on line 133.
- Rationale: the PyTorch `image_uri` is retrieved for `ml.g5.2xlarge` on line 120 and `mlflow.log_param` records `ml.g5.2xlarge` on line 188. The `Compute()` config on line 133 was the only `g6` reference and caused the training pipeline failure flagged by the original author.

### `steps/pipeline_utils.py`
- Unchanged vs main. The f-string quoting fix (single quotes inside an f-string with a double-quoted outer) introduced by fc3ffe17 is a real bug fix and is preserved.

### `args.yaml`
- Replace the hardcoded MLflow tracking server ARN (`arn:aws:sagemaker:ap-northeast-1:364430515305:mlflow-app/app-CVJK6FJPTNDJ`) with an empty placeholder.
- Replace the S3 `model_id` path (perso bucket) with the Hugging Face model id `Qwen/Qwen3-4B-Instruct-2507`.
- Rename the experiment from `qwen3-finetune-pipeline-tokyo` to `qwen3-finetune-pipeline`.
- Note: this file is regenerated at runtime by a `%%bash` cell in `05.01` that builds the SageMaker training config from notebook variables, so checked-in values are template defaults.

### `05.00_fmops_examples.ipynb` and `05.01_fine-tuning-pipeline.ipynb`
- Blank the hardcoded MLflow ARNs.
- Restore the `describe_mlflow_tracking_server` auto-discovery `try/except` block that was commented out, with a fallback to manual paste if the server is not found.
- Clear all execution outputs (account ids, S3 paths, training logs from the original run in `ap-northeast-1`).
- Rename pipeline references from `qwen3-finetune-pipeline-tokyo` to `qwen3-finetune-pipeline`.
- Uncomment the `%pip install` and kernel restart cells so workshop participants with a fresh kernel can run end-to-end (the `05.01` setup markdown explicitly says 'Restart the kernel after executing below cells').
- Remove a dead-code `list_mlflow_apps()` cell from `05.00` that did not assign the variable used downstream.
- Update the surrounding markdown to reflect the new auto-resolve behavior. Previously: 'Update the ARN... copy the tracking server ARN to the variable below.' Now: 'The cell below auto-resolves the MLflow tracking server ARN by name; if you have a different setup, set `mlflow_tracking_server_arn` manually.'
- Soften the `# ENTER YOUR ARN HERE` inline comment to `# Manual fallback if auto-discovery below fails`.
- Dedupe a redundant pair of markdown cells in `05.01` (introduced by fc3ffe17) that both described the MLflow setup.

## Verification

```
$ grep -rn '364430515305\|ap-northeast-1\|tokyo\|CVJK6FJPTNDJ' workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/
(no results)

$ python3 -c "import json; nb=json.load(open('workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.00_fmops_examples.ipynb')); code=[c for c in nb['cells'] if c.get('cell_type')=='code']; print(f'polluted code cells: {sum(1 for c in code if c.get(\"execution_count\") or c.get(\"outputs\"))}/{len(code)}')"
polluted code cells: 0/23

$ python3 -c "import json; nb=json.load(open('workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.01_fine-tuning-pipeline.ipynb')); code=[c for c in nb['cells'] if c.get('cell_type')=='code']; print(f'polluted code cells: {sum(1 for c in code if c.get(\"execution_count\") or c.get(\"outputs\"))}/{len(code)}')"
polluted code cells: 0/16
```

## Out of scope (mentioned in #254 but not addressed here)

- Adding a `.gitignore` rule or `pre-commit` hook to strip notebook outputs — better as a separate PR scoped at the repo level.
- Switching the `describe_mlflow_tracking_server` lookup to `list_mlflow_apps()` — declined because this workshop targets the older tracking-server flow, not the newer MLflow App resource.
- Changing the Workshop Studio environment to `git clone` at session start — that is a Workshop Studio configuration change, not a repo change.

## Context

We are running a public Immersion Day on **June 4, 2026** based on this workshop (the AIM402 session from AWS Summit Paris 2026, 50+ registered as of 2026-05-22). `task_05_fmops` is a core part of the agenda, so we wanted main to be unblocked before then.

Tagging the task owners for visibility: @sciarrilli @giuseppe-zappia @brunopistone.