### PR TITLE
fix(task_05_fmops): upgrade judge model from legacy Sonnet 4 to Sonnet 4.6

### DIFF
--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.00_fmops_examples.ipynb
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/05.00_fmops_examples.ipynb
@@ -459,9 +459,9 @@
    "metadata": {},
    "source": [
     "### 5. Qualitative Model Evaluation\n",
-    "Let's test the default Qwen3-4B-Instruct-2507 using MLFlow's LLM-as-a-Judge capability. We'll use [Anthropic's Claude Sonnet 4](https://www.anthropic.com/news/claude-4) model on [Amazon Bedrock](https://aws.amazon.com/bedrock/) as the judge. We'll also wrap our model endpoint invocation in a method making it easier to call in the evaluation. \n",
+    "Let's test the default Qwen3-4B-Instruct-2507 using MLFlow's LLM-as-a-Judge capability. We'll use [Anthropic's Claude Sonnet 4.6](https://www.anthropic.com/news/claude-4) model on [Amazon Bedrock](https://aws.amazon.com/bedrock/) as the judge. We'll also wrap our model endpoint invocation in a method making it easier to call in the evaluation. \n",
     "\n",
-    "This particular endpoint is the [global cross-region inference endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html) name for Claude Sonnet 4.\n",
+    "This particular endpoint is the [global cross-region inference endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html) name for Claude Sonnet 4.6.\n",
     "\n",
     "Wrapping our invocation in a separate method allows us to trace evaluation calls to the model using the `@mlflow.trace` annotation. These traces will appear in our MLFlow experiment under the \"Traces\" tab.\n",
     "\n",
@@ -474,8 +474,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# judge_llm = \"bedrock:/anthropic.claude-3-haiku-20240307-v1:0\"\n",
-    "judge_llm = \"bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0\""
+    "judge_llm = \"bedrock:/global.anthropic.claude-sonnet-4-6\""
    ]
   },
   {

--- a/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/steps/qualitative_eval_step.py
+++ b/workshops/fine-tuning-with-sagemakerai-and-bedrock/task_05_fmops/steps/qualitative_eval_step.py
@@ -144,8 +144,7 @@ def qualitative_evaluate(
             ),
             examples=medical_accuracy_examples,
             version="v1",
-            # model="bedrock:/us.anthropic.claude-3-haiku-20240307-v1:0",
-            model="bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0",
+            model="bedrock:/global.anthropic.claude-sonnet-4-6",
             parameters={
                 "anthropic_version": "bedrock-2023-05-31",
                 "temperature": 0.0,
@@ -193,8 +192,7 @@ def qualitative_evaluate(
             ),
             examples=clinical_reasoning_examples,
             version="v1",
-            # model="bedrock:/us.anthropic.claude-3-haiku-20240307-v1:0",
-            model="bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0",
+            model="bedrock:/global.anthropic.claude-sonnet-4-6",
             parameters={
                 "anthropic_version": "bedrock-2023-05-31",
                 "temperature": 0.0,
@@ -240,8 +238,7 @@ def qualitative_evaluate(
             ),
             examples=patient_safety_examples,
             version="v1",
-            # model="bedrock:/us.anthropic.claude-3-haiku-20240307-v1:0",
-            model="bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0",
+            model="bedrock:/global.anthropic.claude-sonnet-4-6",
             parameters={
                 "anthropic_version": "bedrock-2023-05-31",
                 "temperature": 0.0,
@@ -475,7 +472,7 @@ def qualitative_evaluate(
             mlflow.log_param("qualitative_evaluation_endpoint", endpoint_name)
             mlflow.log_param("qualitative_evaluation_num_samples", num_samples)
             mlflow.log_param("qualitative_evaluation_timestamp", datetime.now().isoformat())
-            mlflow.log_param("llm_judge_model", "bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0")
+            mlflow.log_param("llm_judge_model", "bedrock:/global.anthropic.claude-sonnet-4-6")
             
             # Load the test dataset
             try:


### PR DESCRIPTION
## Problem

The `QualitativeModelEvaluation` pipeline step fails with:

```
Float cannot represent non numeric value: nan
```

This error occurs 6 times (3 metrics × 2 aggregations: mean + variance).

## Root Cause

The LLM-as-a-judge model `claude-sonnet-4-20250514-v1:0` has been **marked as Legacy** by Anthropic on Amazon Bedrock. When a model is Legacy and hasn't been used in the last 30 days, Bedrock rejects all invocations with:

```
ResourceNotFoundException: Access denied. This Model is marked by provider as Legacy
and you have not been actively using the model in the last 30 days.
```

This causes `make_genai_metric` to silently fail on every judge call → all scores become `None` → aggregated as `NaN` → the SageMaker Managed MLflow tracking server (GraphQL API) rejects NaN float values.

The downstream `EvaluationGate` step also fails with `Incompatible types in BinaryCondition left type [String], right type [Float]` because the qualitative result is not a valid float.

## Fix

Replace all references to the legacy model ID with the active `claude-sonnet-4-6`:

- `bedrock:/global.anthropic.claude-sonnet-4-20250514-v1:0` → `bedrock:/global.anthropic.claude-sonnet-4-6`

Also removed commented-out references to the legacy `claude-3-haiku-20240307-v1:0`.

## Files Changed

- `steps/qualitative_eval_step.py` — 3 metric definitions + 1 log_param
- `05.00_fmops_examples.ipynb` — judge_llm variable + markdown description

## Testing

Pipeline executed end-to-end successfully after the fix:
- `QualitativeModelEvaluation`: ✅ Succeeded (real scores logged)
- `EvaluationGate`: ✅ Succeeded
- `ModelRegistration`: ✅ Succeeded