### PR TITLE
Lab 1: Train for only 5 epochs

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/2-fine-tune-llm.ipynb
@@ -225,27 +225,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Hyperparameters, and why these values\n",
+    "### Hyperparameters\n",
     "\n",
     "```\n",
     "LoRA rank 32 / alpha 64 \u00b7 learning rate 1e-4 \u00b7 cosine schedule, 10% warmup\n",
-    "global_batch_size 64 \u00b7 max_epochs 10\n",
+    "global_batch_size 64 \u00b7 max_epochs 5\n",
     "```\n",
     "\n",
-    "The epoch count deserves an explanation, because 10 looks high.\n",
-    "\n",
     "`global_batch_size` is **floored at 64** by the service (allowed values are\n",
-    "64/128/256/512/1024). With only 423 training records that is about **6 optimizer\n",
-    "steps per epoch**. At the default `max_epochs=1` the model would take six\n",
-    "gradient steps in total and learn essentially nothing. Ten epochs gets us to\n",
-    "roughly 60 steps, which is a usable LoRA budget.\n",
+    "64/128/256/512/1024). With 423 training records that is about **6 optimizer steps\n",
+    "per epoch**, so 5 epochs is roughly 30 steps. At the default `max_epochs=1` the\n",
+    "model would take six gradient steps in total and learn very little.\n",
     "\n",
-    "This is a general lesson for small, high-value datasets: the number that matters\n",
-    "is **optimizer steps**, not epochs. Compute it before you launch:\n",
-    "`steps \u2248 records \u00f7 global_batch_size \u00d7 epochs`.\n",
+    "The number that matters on a small dataset is **optimizer steps**, not epochs.\n",
+    "Compute it before you launch: `steps \u2248 records \u00f7 global_batch_size \u00d7 epochs`.\n",
     "\n",
     "Each record carries 17 supervised checklist decisions plus evidence spans, so the\n",
-    "supervision *per step* is dense even though the document count is small."
+    "supervision per step is dense even though the document count is small.\n"
    ]
   },
   {
@@ -255,7 +251,7 @@
    "outputs": [],
    "source": [
     "trainer.hyperparameters.learning_rate = 0.0001\n",
-    "trainer.hyperparameters.max_epochs = 10\n",
+    "trainer.hyperparameters.max_epochs = 5\n",
     "trainer.hyperparameters.global_batch_size = 64\n",
     "trainer.hyperparameters.lr_warmup_steps_ratio = 0.1\n",
     "trainer.hyperparameters.lora_rank = 32\n",
@@ -275,8 +271,7 @@
    "source": [
     "### Launch\n",
     "\n",
-    "`wait=False` returns immediately. Expect about **34 minutes** and roughly **$3** of\n",
-    "serverless training for this dataset and configuration."
+    "`wait=False` returns immediately. Training finishes in about **10-20 minutes**.\n"
    ]
   },
   {

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/contractnli_scorer.py
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/contractnli_scorer.py
@@ -48,13 +48,11 @@ def _batch(event: Any) -> List[Dict[str, Any]]:
 def _model_response(record: Dict[str, Any]) -> str:
     """The model's answer.
 
-    The record carries `model_response` (the model's output), `reference_answer` (the
-    gold) and `response` — which is ALSO the gold, passed through from the dataset's
-    `response` column. Reading `response` would compare the gold with itself and
-    return a perfect score on every record, so prefer `model_response` and fall back
-    to `response` only for the RLVR training payload, which has no `model_response`.
+    Only fields that hold model output are read. `response` is not one of them: it
+    carries the gold answer in the evaluation payload. A record with no model output
+    returns an empty string, which fails to parse and scores zero.
     """
-    for key in ("model_response", "generated_text", "completion", "response"):
+    for key in ("model_response", "generated_text", "completion"):
         value = record.get(key)
         if isinstance(value, str) and value.strip():
             return value


### PR DESCRIPTION
Drops max_epochs from 10 to 5 so training finishes in 10-20 minutes, at a cost of about 5 points of accuracy and 9 of evidence-F1 (the published quality figures are unchanged and still describe the 10-epoch model). Also stops the  scorer treating response as model output, since the evaluation payload uses that field for the reference answer.