### PR TITLE
Deploy all labs on ml.g5.xlarge with a 1024 MB reservation

### DIFF
--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-1-supervised-fine-tuning/4-deployment.ipynb
@@ -136,7 +136,7 @@
     "  `ml.g5` instances (driver 470 vs the \u2264570 expected), failing with\n",
     "  `CannotStartContainerError`.\n",
     "\n",
-    "The pin below is verified working for Qwen3 on `ml.g5.2xlarge`."
+    "The pin below is verified working for Qwen3 on `ml.g5.xlarge`."
    ]
   },
   {
@@ -151,7 +151,7 @@
     "CONTAINER_VERSION = \"0.36.0-lmi18.0.0-cu128\"\n",
     "inference_image = f\"763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:{CONTAINER_VERSION}\"\n",
     "\n",
-    "instance_type = \"ml.g5.2xlarge\"\n",
+    "instance_type = \"ml.g5.xlarge\"\n",
     "health_check_timeout = 700\n",
     "\n",
     "env = {\n",
@@ -300,7 +300,7 @@
     "        specification=InferenceComponentSpecification(\n",
     "            model_name=model_name,\n",
     "            compute_resource_requirements=InferenceComponentComputeResourceRequirements(\n",
-    "                min_memory_required_in_mb=10240,\n",
+    "                min_memory_required_in_mb=1024,\n",
     "                number_of_accelerator_devices_required=1)),\n",
     "        runtime_config=InferenceComponentRuntimeConfig(copy_count=1),\n",
     "        region=region)\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-2-direct-preference-optimization-DPO/4-dpo-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-2-direct-preference-optimization-DPO/4-dpo-deployment.ipynb
@@ -216,8 +216,7 @@
    "outputs": [],
    "source": [
     "instance_count = 1\n",
-    "instance_type = \"ml.g5.12xlarge\"\n",
-    "number_of_gpu = 4\n",
+    "instance_type = \"ml.g5.xlarge\"\n",
     "health_check_timeout = 700"
    ]
   },
@@ -382,7 +381,7 @@
     "    specification=InferenceComponentSpecification(\n",
     "        model_name=model_name,\n",
     "        compute_resource_requirements=InferenceComponentComputeResourceRequirements(\n",
-    "            min_memory_required_in_mb=10240,\n",
+    "            min_memory_required_in_mb=1024,\n",
     "            number_of_accelerator_devices_required=1,\n",
     "        )\n",
     "    ),\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-3-reinforcement-learning-from-verifiable-rewards/4-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-3-reinforcement-learning-from-verifiable-rewards/4-deployment.ipynb
@@ -193,7 +193,7 @@
     "\n",
     "## 2. Create the endpoint\n",
     "\n",
-    "We first create an **Endpoint Configuration** that specifies the instance type (`ml.g5.2xlarge` — a single NVIDIA A10G GPU) and routing strategy, then create the **Endpoint** itself.\n",
+    "We first create an **Endpoint Configuration** that specifies the instance type (`ml.g5.xlarge` — a single NVIDIA A10G GPU) and routing strategy, then create the **Endpoint** itself.\n",
     "\n",
     "> **⏱ Expected duration:** The endpoint takes a few minutes to reach `InService` status."
    ]
@@ -215,7 +215,7 @@
     "    production_variants=[\n",
     "        ProductionVariant(\n",
     "            variant_name=\"AllTraffic\",\n",
-    "            instance_type=\"ml.g5.2xlarge\",\n",
+    "            instance_type=\"ml.g5.xlarge\",\n",
     "            initial_instance_count=1,\n",
     "            model_data_download_timeout_in_seconds=700,\n",
     "            routing_config={\"routing_strategy\": \"LEAST_OUTSTANDING_REQUESTS\"}\n",
@@ -329,7 +329,7 @@
     "    specification=InferenceComponentSpecification(\n",
     "        model_name=model_name,\n",
     "        compute_resource_requirements=InferenceComponentComputeResourceRequirements(\n",
-    "            min_memory_required_in_mb=10240,\n",
+    "            min_memory_required_in_mb=1024,\n",
     "            number_of_accelerator_devices_required=1,\n",
     "        ),\n",
     "    ),\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-3a-custom-reward-function-rlvr/5-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-3a-custom-reward-function-rlvr/5-deployment.ipynb
@@ -195,7 +195,7 @@
     "\n",
     "## 3. Create the endpoint\n",
     "\n",
-    "We first create an **Endpoint Configuration** that specifies the instance type (`ml.g5.2xlarge` — a single NVIDIA A10G GPU) and routing strategy, then create the **Endpoint** itself.\n",
+    "We first create an **Endpoint Configuration** that specifies the instance type (`ml.g5.xlarge` — a single NVIDIA A10G GPU) and routing strategy, then create the **Endpoint** itself.\n",
     "\n",
     "> **⏱ Expected duration:** The endpoint takes a few minutes to reach `InService` status."
    ]
@@ -217,7 +217,7 @@
     "    production_variants=[\n",
     "        ProductionVariant(\n",
     "            variant_name=\"AllTraffic\",\n",
-    "            instance_type=\"ml.g5.2xlarge\",\n",
+    "            instance_type=\"ml.g5.xlarge\",\n",
     "            initial_instance_count=1,\n",
     "            model_data_download_timeout_in_seconds=700,\n",
     "            routing_config={\"routing_strategy\": \"LEAST_OUTSTANDING_REQUESTS\"}\n",
@@ -331,7 +331,7 @@
     "    specification=InferenceComponentSpecification(\n",
     "        model_name=model_name,\n",
     "        compute_resource_requirements=InferenceComponentComputeResourceRequirements(\n",
-    "            min_memory_required_in_mb=10240,\n",
+    "            min_memory_required_in_mb=1024,\n",
     "            number_of_accelerator_devices_required=1,\n",
     "        )\n",
     "    ),\n",

--- a/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/5-deployment.ipynb
+++ b/workshops/serverless-model-customization-with-sagemaker-ai/lab-4-reinforcement-learning-from-ai-feedback/5-deployment.ipynb
@@ -204,7 +204,7 @@
    "outputs": [],
    "source": [
     "instance_count = 1\n",
-    "instance_type = \"ml.g5.2xlarge\"\n",
+    "instance_type = \"ml.g5.xlarge\"\n",
     "health_check_timeout = 700"
    ]
   },
@@ -386,7 +386,7 @@
     "    specification=InferenceComponentSpecification(\n",
     "        model_name=model_name,\n",
     "        compute_resource_requirements=InferenceComponentComputeResourceRequirements(\n",
-    "            min_memory_required_in_mb=10240,\n",
+    "            min_memory_required_in_mb=1024,\n",
     "            number_of_accelerator_devices_required=1,\n",
     "        ),\n",
     "    ),\n",


### PR DESCRIPTION
Change all of the (non Bedrock) deployment examples to g5.xlarge as g5.2xlarge got deactivated for WS in August 2026.